### PR TITLE
fix: Various typos in datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 _config.ci.yml
 .parcel-cache
 vendor
+linters_logs/
+megalinter-reports/

--- a/_datasets/delaware-river-basin-2070-land-cover-forecast.md
+++ b/_datasets/delaware-river-basin-2070-land-cover-forecast.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "DRB2070 Version 1.0 represents a baseline forecast of urban land cover in\
   \ the Delaware River Basin (DRB) out to the year 2070. It was developed by the Delaware\
-  \ River Basin Land Use Dynamics Project at Shippensburg Unviersity. The forecasts\
+  \ River Basin Land Use Dynamics Project at Shippensburg University. The forecasts\
   \ were developed using a SLEUTH urban growth model for the 43 county region of the\
   \ DRB over the 2001-2006 time period. The model was validated for the 2006-2011\
   \ time period. The modeling team used the National Land Cover Database (NLCD) urban\

--- a/_datasets/major-watersheds-philadelphia.md
+++ b/_datasets/major-watersheds-philadelphia.md
@@ -28,7 +28,7 @@ resources:
   url: https://opendata.arcgis.com/datasets/73f97f2c6c634469a81dd7721661b63f_0.zip
 - description: ''
   format: GeoJSON
-  name: Major Watersheds - Philadelphis (GeoJSON)
+  name: Major Watersheds - Philadelphia (GeoJSON)
   url: https://opendata.arcgis.com/datasets/73f97f2c6c634469a81dd7721661b63f_0.geojson
 - description: ''
   format: api

--- a/_datasets/patco-gtfs.md
+++ b/_datasets/patco-gtfs.md
@@ -20,7 +20,7 @@ schema: philadelphia
 source: http://www.ridepatco.org/developers/
 tags:
 - gtfs
-- transporation
+- transportation
 time_period: null
 title: PATCO GTFS
 usage: null

--- a/_datasets/recycling-diversion-rate.md
+++ b/_datasets/recycling-diversion-rate.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category: []
 created: '2015-01-16T16:55:08.083099'
 license: Other (City of Philadelphia)
-maintainer: Max Steinbrenne
+maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null

--- a/_datasets/vending-prohibited-areas.md
+++ b/_datasets/vending-prohibited-areas.md
@@ -18,7 +18,7 @@ organization: City of Philadelphia
 resources:
 - description: ''
   format: CSV
-  name: Vending Prohbitied Areas (CSV)
+  name: Vending Prohibited Areas (CSV)
   url: https://opendata.arcgis.com/api/v3/datasets/ce24c5700c7b4c70bead03181934c573_0/downloads/data?format=csv&spatialRefId=4326
 - description: ''
   format: SHP

--- a/_organizations/port-authority-transit-corporation-patco.md
+++ b/_organizations/port-authority-transit-corporation-patco.md
@@ -4,6 +4,6 @@ logo: http://www.ridepatco.org/images/header_logo.png
 schema: default
 tags:
 - gtfs
-- transporation
+- transportation
 title: Port Authority Transit Corporation (PATCO)
 ---


### PR DESCRIPTION
I ran CSpell locally, and using its generated recommended config file, noticed a few typos in display values.

This PR fixes those.

Also adds the listing reporting folders to `.gitignore` so that Git doesn't recommend to commit them to the repo.