### PR TITLE
chore: Update wording on a few pages

### DIFF
--- a/_datasets/bike-network-supporting-datasets.md
+++ b/_datasets/bike-network-supporting-datasets.md
@@ -14,8 +14,8 @@ notes: "This dataset combines data from various City of Philadelphia departments
   \ order to create a set of supporting documentation for bike network routing. Datasets\
   \ include Bike Network, Connector Streets, Regional Routes, and Trails and Side\
   \ paths. Each dataset has its own parameters, dates, and sources, and individuals\
-  \ are encouraged to view the metadata associated with this data. \r\n<br></br>\r\
-  \nThis dataset is experimental and remains a work in progress. Please use with caution."
+  \ are encouraged to view the metadata associated with this data. \r\n\r\n
+  \ <i>This dataset is experimental and remains a work in progress. Please use with caution.</i>"
 opendataphilly_rating: null
 organization: City of Philadelphia
 resources:

--- a/_datasets/city-council-districts.md
+++ b/_datasets/city-council-districts.md
@@ -8,8 +8,7 @@ maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null
 maintainer_phone: null
-notes: "City Council Districts (1990),\r\nCity Council Districts (2000), and\r\nCity\
-  \ Council Districts (2016)\r\n\r\n"
+notes: "City Council Districts for a variety of different years."
 opendataphilly_rating: null
 organization: City of Philadelphia
 resources:


### PR DESCRIPTION
Updates the wording on a few dataset pages:

* I noticed on the Bike Network page, it was showing the line break text `</br>`.  This fixes that, and marks the "warning" in clear italics.

  | Before | After |
  | --- | --- |
  | <img width="1139" alt="image" src="https://github.com/opendataphilly/opendataphilly-jkan/assets/33203301/b3c28d71-9fd7-4543-825d-609c71090081"> | <img width="1139" alt="image" src="https://github.com/opendataphilly/opendataphilly-jkan/assets/33203301/cef71e79-fcbc-442b-a90c-12aa1aa93bc0"> |

* The City Councils page note listed three different years, but the data itself had 2024 added to it. Rather than saying WHAT years are there, just state it generically so more years can be added over time. (or removed, as necessary)

Verified these changes locally using `docker compose up` and local Jekyll running.