### PR TITLE
chore(ci): Bump GitHub Action workflows to latest major versions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@d37167af451eb51448db3354e1057b75c4b268f7 # v1.155.0
         with:
@@ -37,7 +37,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Write metadata to a file Jekyll can use
         env:
           BRANCH: ${{ github.ref_name }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Some spring cleaning 🧹 .

I noticed in the CI output that GitHub Actions was warning about an older version of Node v16 being used which is deprecated. I believe this is due to some of the GH-provided actions.

<img width="1021" alt="image" src="https://github.com/opendataphilly/opendataphilly-jkan/assets/33203301/af27230f-cbac-477b-82a8-1e325d2c180e">

This PR bumps the GH provided ones. In particular, to use upload-artifact v3 you must also use deploy v4 based on how the upload/download was changed. There's another breaking change in there re: file modes, but looking at the CI output this workflow is not affected by that.

I've left the pinned Ruby action for now for future maintenance.

This also gets many bug fixes, and suggests the artifact workflow is significantly faster (even though CI runs pretty quickly here anyway).