### PR TITLE
chore(ci): Bump Ruby action to remove legacy Node 16 dependency

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@d37167af451eb51448db3354e1057b75c4b268f7 # v1.155.0
+        uses: ruby/setup-ruby@d03597fde829e5c04aeebf68e15407f31c00ff02 # v1.160.0
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems


### PR DESCRIPTION
The Actions pipeline currently still has a remaining warning about Node 16 deprecation:

<img width="1212" alt="image" src="https://github.com/opendataphilly/opendataphilly-jkan/assets/33203301/e189cd49-85bc-4e1e-aa61-c7cfbaa20e39">

It's currently at v1.155 from Oct 2023; this bumps it just to a version in Nov 2023 which includes the bump to Node 20 (and a patch to fix a slowdown found in Node 20) as an incremental improvement.  Opted not to entirely jump to the newest as the project likely doesn't need those newest Ruby inclusions (yet).

https://github.com/ruby/setup-ruby/releases/tag/v1.160.0