### PR TITLE
Update connection to organization

### DIFF
--- a/_datasets/buy-fresh-buy-local-pa.md
+++ b/_datasets/buy-fresh-buy-local-pa.md
@@ -19,11 +19,11 @@ notes: Buy Fresh, Buy Local is an online application that enables users to acces
   for Sustainable Agriculture. Free registration enables commenting, blogging, uploading
   recipes and other interactive features.
 opendataphilly_rating: null
-organization: Buy Fresh Buy Local PA
+organization: Pasa Sustainable Agriculture
 resources:
 - description: Map of locally produced food locations
   format: HTML
-  name: 'Buy Fresh Buy Local PA '
+  name: 'Buy Fresh Buy Local PA'
   url: https://buyfreshbuylocal.org/pennsylvania/
 schema: default
 source: null


### PR DESCRIPTION
The org name was changed to Pasa Sustainabl Agriculture, so the organization attribute needs to match. Part of #123 logo fixes.