### PR TITLE
Update CHA visualization URL

### DIFF
--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -1,14 +1,11 @@
 ---
-area_of_interest: null
+area_of_interest: City of Philadelphia
 category:
-- Economy
-- Education
-- Food
 - Health / Human Services
-created: '2015-10-07T13:29:47.073232'
+created: 
 license: Other (City of Philadelphia)
 maintainer: ''
-maintainer_email: ''
+maintainer_email: 'epi@phila.gov'
 maintainer_link: null
 maintainer_phone: null
 notes: "The Community Health Assessment (CHA) is a systematic assessment of population\
@@ -19,15 +16,15 @@ notes: "The Community Health Assessment (CHA) is a systematic assessment of popu
   \ of Public Health publishes an annual report of the analyses, linked to under the\
   \ 'Related' tab. Additionally, they have released an online, interactive version\
   \ of the CHA, known as the Community Health Explorer, to make the data more accessible\
-  \ to a broader audience: http://cityofphiladelphia.github.io/community-health-explorer/\r\n\r\n\r\n"
+  \ to a broader audience: https://cityofphiladelphia.github.io/community-health-explorer/\r\n\r\n\r\n"
 opendataphilly_rating: null
 organization: City of Philadelphia
 resources:
-- description: 'Interactive web application to see charts and maps of the community
+- description: 'Interactive report with charts and maps of the community
     health assessment data for Philadelphia. '
   format: HTML
-  name: Community Health Explorer (Visualization)
-  url: https://philadelphiapublichealth.shinyapps.io/health-of-the-city/
+  name: Community Health Exporer
+  url: https://healthexplorer.phila.gov/
 - description: ''
   format: CSV
   name: Planning Districts 2017 (CSV)
@@ -47,7 +44,7 @@ resources:
 - description: ''
   format: HTML
   name: Community Health Assessment (Metadata)
-  url: http://metadata.phila.gov/#home/datasetdetails/56142af5210dfc8711e84a7f/
+  url: https://metadata.phila.gov/#home/datasetdetails/56142af5210dfc8711e84a7f/
 schema: philadelphia
 source: ''
 tags:

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -16,7 +16,7 @@ notes: "The Community Health Assessment (CHA) is a systematic assessment of popu
   \ of Public Health publishes an annual report of the analyses, linked to under the\
   \ 'Related' tab. Additionally, they have released an online, interactive version\
   \ of the CHA, known as the Community Health Explorer, to make the data more accessible\
-  \ to a broader audience: https://cityofphiladelphia.github.io/community-health-explorer/\r\n\r\n\r\n"
+  \ to a broader audience."
 opendataphilly_rating: null
 organization: City of Philadelphia
 resources:

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -23,7 +23,7 @@ resources:
 - description: 'Interactive web application with charts and maps of the community
     health assessment data for Philadelphia. '
   format: HTML
-  name: Community Health Exporer
+  name: Community Health Exporer (Visualization)
   url: https://healthexplorer.phila.gov/
 - description: ''
   format: CSV

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -2,7 +2,7 @@
 area_of_interest: City of Philadelphia
 category:
 - Health / Human Services
-created: 
+created: '2015-10-07T13:29:47.073232'
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: 'epi@phila.gov'

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -27,7 +27,7 @@ resources:
     health assessment data for Philadelphia. '
   format: HTML
   name: Community Health Explorer (Visualization)
-  url: http://cityofphiladelphia.github.io/community-health-explorer/
+  url: https://philadelphiapublichealth.shinyapps.io/health-of-the-city/
 - description: ''
   format: CSV
   name: Planning Districts 2017 (CSV)

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -20,7 +20,7 @@ notes: "The Community Health Assessment (CHA) is a systematic assessment of popu
 opendataphilly_rating: null
 organization: City of Philadelphia
 resources:
-- description: 'Interactive report with charts and maps of the community
+- description: 'Interactive web application with charts and maps of the community
     health assessment data for Philadelphia. '
   format: HTML
   name: Community Health Exporer


### PR DESCRIPTION
Old redirect from cityofphiladelphia.github.io to https://healthexplorer.phila.gov/ not working. 

Found new URL from https://www.phila.gov/departments/department-of-public-health/data/ and https://www.phila.gov/documents/health-of-the-city/