### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@d03597fde829e5c04aeebf68e15407f31c00ff02 # v1.160.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems


### PR DESCRIPTION
The Setup Ruby step was using an old version based on a deprecated runner image.

Merging this should resolve the issue Robert was seeing in [this build](https://github.com/opendataphilly/opendataphilly-jkan/actions/runs/12616170566/job/35174060097) in [a recent PR](https://github.com/opendataphilly/opendataphilly-jkan/pull/317).