### PR TITLE
Sync with upstream (Jan 9, 2025)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM ruby:3.2-bullseye
+FROM ruby:3.2-bookworm
 
-ENV NODE_MAJOR_VERSION 18
-
-RUN curl --silent --show-error --location --retry 5 --retry-connrefuse --retry-delay 4 https://deb.nodesource.com/setup_${NODE_MAJOR_VERSION}.x | bash - \
-  && apt-get update \
-  && apt-get install -y --quiet --no-install-recommends \
-  nodejs
+RUN apt-get update \
+ && apt-get install -y --quiet --no-install-recommends \
+ nodejs npm
 
 ENV GEM_HOME=/usr/gem
 ENV PATH="$GEM_HOME/bin/:$PATH" 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,8 +3,7 @@
     <a alt="{{ site.title }}" class="navbar-brand" href="{{ site.baseurl }}/">
       <img src="{{ site.logo }}" srcset="/img/odp-logo@2x.png 2x" alt="OpenDataPhilly" title="OpenDataPhilly">
     </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="sr-only">Toggle navigation</span>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,10 @@
-<nav class="navbar navbar-expand-sm mb-4 navbar-light" data-component="navigation">
+<nav class="navbar navbar-expand-sm mb-4 navbar-dark" data-component="navigation">
   <div class="container">
     <a alt="{{ site.title }}" class="navbar-brand" href="{{ site.baseurl }}/">
       <img src="{{ site.logo }}" srcset="/img/odp-logo@2x.png 2x" alt="OpenDataPhilly" title="OpenDataPhilly">
+    </a>
+    <a class="github-logo d-md-none" href="https://github.com/opendataphilly/opendataphilly-jkan">
+      <img src="{{site.baseurl}}/img/github-mark-white.svg" width="30" height="30">
     </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -17,9 +20,8 @@
         {% endfor %}
       </ul>
     </div>
-    <a class="github-logo" href="https://github.com/azavea/opendataphilly-jkan">
+    <a class="github-logo d-none d-md-block" href="https://github.com/opendataphilly/opendataphilly-jkan">
       <img src="{{site.baseurl}}/img/github-mark-white.svg" width="30" height="30">
     </a>
-
   </div>
 </nav>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - JEKYLL_ENV=development
       - LANG=C.UTF-8
-    command: jekyll serve --watch --incremental --host 0.0.0.0
+    command: bundle exec jekyll serve --watch --incremental --host 0.0.0.0
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
Okay folks, so we have gotten ourselves into a bit of a mess with diverging histories from upstream. This is made a bit more challenging because we're no longer technically a fork of JKAN on GitHub, so we can't use any of GitHub's tooling to sync up.

I'll leave [the branch](https://github.com/opendataphilly/opendataphilly-jkan/compare/20240702-pull-upstream?expand=1) up until this PR is merged so you can see for yourself, but for posterity, this is what the result of a rebase looked like when i tried in July (sorry for taking so long to get back to this 😅):

<img width="340" alt="Screenshot 2025-01-09 at 8 18 39 AM" src="https://github.com/user-attachments/assets/e3cdde0c-0182-4289-bf2f-0b2de8cb8715" />


Many of the new "changes" seem to just be files and lines we already have, so not sure what happened there.

Then i tried merging and resolving the conflicts, but this felt like an error prone process, and confusingly that PR wouldn't merge unless i squashed all of the commits. The whole PR was starting to feel like no matter what it would make our history much messier. [See here](https://github.com/opendataphilly/opendataphilly-jkan/pull/251).

So this morning i decided to just go through and cherry-pick the specific commits from upstream and resolve a couple issues that came up in the process. I'm going to make a separate upstream PR when i have time to make sure that jkan isn't missing any important improvements from our end, but that's the excruciatingly long story behind this little set of changes.
