### PR TITLE
Adding rendering of tags element to dataset.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _config.ci.yml
 vendor
 linters_logs/
 megalinter-reports/
+.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ _config.ci.yml
 vendor
 linters_logs/
 megalinter-reports/
-.code-workspace
+*.code-workspace

--- a/OpenDataPhilly-jkan.code-workspace
+++ b/OpenDataPhilly-jkan.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/OpenDataPhilly-jkan.code-workspace
+++ b/OpenDataPhilly-jkan.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {}
-}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -88,6 +88,16 @@ layout: default
               {% endif %}
             {% endunless %}
           {% endfor %}
+          {% if page.tags %}
+          <tr>
+            <th>Tags</th>
+            <td>
+              {% for tag in page.tags %}
+              <span>{{ tag }}</span>
+              {% endfor %}
+            </td>
+          </tr>
+          {% endif %}
 
         </table>
         <a href="{{site.github.repository_url}}/tree/main/{{page.path}}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>


### PR DESCRIPTION
The City has been adding dataset agency info to the `tags` element in dataset markdown files, but this element has not been rendered.

This change aims to render `tags` when they are available in a dataset markdown file.

Issue #308

NOTE: I accidentally added a VS code workspace file and think I deleted it, but I'm not entirely sure, so please delete this if it turns out my delete was unsuccessful.