### PR TITLE
delinked url for historical society of pa to prevent breaking org card

### DIFF
--- a/_organizations/historical-society-of-pennsylvania.md
+++ b/_organizations/historical-society-of-pennsylvania.md
@@ -7,7 +7,7 @@ description: "Founded in 1824 in Philadelphia, the Historical Society of Pennsyl
    its 17th-century origins to the contributions of its most recent immigrants. The
    society's remarkable holdings together with its educational programming make
    it one of the nation's most important special collections libraries: a center
-   of historical documentation and study, education, and engagement. [https://hsp.org/](https://hsp.org/)"
+   of historical documentation and study, education, and engagement. https://hsp.org/"
 logo: img/organizations/logo-hsp.gif
 schema: default
 tags: []


### PR DESCRIPTION
Fixes #49 .

Addresses the card issue formatting issue in /organizations for Historical Society of Pennsylvania. Will now look like:

![{E8EB4A20-64B5-4CB8-B523-61DCD852583B}](https://github.com/user-attachments/assets/0f81648d-95ec-4284-a687-336c229259e7)
