### PR TITLE
added skip to main content for a11y

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,5 @@
+{% include skip-to-content.html %}
+
 <nav class="navbar navbar-expand-sm mb-4 navbar-dark" data-component="navigation">
   <div class="container">
     <a alt="{{ site.title }}" class="navbar-brand" href="{{ site.baseurl }}/">

--- a/_includes/skip-to-content.html
+++ b/_includes/skip-to-content.html
@@ -1,0 +1,1 @@
+<a href="#main-content" class="skip-to-content">skip to main content</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
 
     {% include header.html %}
 
-    <section data-hook="main" class="container">
+    <section data-hook="main" class="container" id="main-content">
       {{ content }}
     </section>
 

--- a/css/main.css
+++ b/css/main.css
@@ -135,3 +135,25 @@ nav {
   background-color: #20c3c4;
   border-radius: 4px;
 }
+
+.skip-to-content {
+  background-color: #61c3c4;
+  border-top: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+  border-right: 2px solid #fff;
+  color: #fff;
+  font-size: 1.25rem;
+  left: 0;
+  padding: 5px 10px;
+  position: absolute;
+  text-decoration: underline;
+  top: -45px;
+  transition: scale(1);
+  z-index: 999
+}
+
+.skip-to-content:focus, .skip-to-content:active {
+  color: #fff;
+  outline: none;
+  top: 0;
+}


### PR DESCRIPTION
Closes #341.

On any of the pages, while at the first tab index of the page, if you use a keyboard and press tab, this will popup:

<img width="635" alt="skip to main content screenshot" src="https://github.com/user-attachments/assets/760d616a-78cd-4b9c-b57b-b44600fd521f" />


I added two styles to css/main.css for the class .skip-to-content.
I added a skip-to-content.html include.
I modified the default layout to add an id, _main-content_, to the main div, which is used for the _skip to main content_ anchor link.
I modified the header.html include to add an include statement at the top, above the nav tag, to import the skip-to-content.html include.