### PR TITLE
add licenses pages in order to support DCAT license element

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,9 @@ collections:
   dataset_categories:
     output: true
     permalink: /categories/:path/
+  licenses:
+    output: true
+    permalink: /licenses/:path/
 
 # Collections (cont'd)
 defaults:

--- a/_data/licenses.yml
+++ b/_data/licenses.yml
@@ -1,17 +1,7 @@
 items:
-  - name: Creative Commons Attribution
+  - name: Creative Commons 4.0
     url: https://creativecommons.org/licenses/by/4.0/
-  - name: Creative Commons Attribution Share-Alike
-    url: https://creativecommons.org/licenses/by-sa/4.0/
-  - name: Creative Commons CCZero
-    url: https://creativecommons.org/publicdomain/zero/1.0/
-  - name: UK Open Government Licence
-    url: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-  - name: Open Data Commons Attribution License
-    url: http://www.opendefinition.org/licenses/odc-by
-  - name: Open Data Commons Open Database License (ODbL)
-    url: http://www.opendefinition.org/licenses/odc-odbl
-  - name: Open Data Commons Public Domain Dedication and Licence (PDDL)
-    url: http://www.opendefinition.org/licenses/odc-pddl
-  - name: Not Applicable
-    url: ""
+  - name: City of Philadelphia License
+    url: https://opendataphilly.org/licenses/city-of-philadelphia
+  - name: Other License
+    url: https://opendataphilly.org/licenses/other

--- a/_data/licenses.yml
+++ b/_data/licenses.yml
@@ -2,6 +2,6 @@ items:
   - name: Creative Commons 4.0
     url: https://creativecommons.org/licenses/by/4.0/
   - name: City of Philadelphia License
-    url: https://opendataphilly.org/licenses/city-of-philadelphia
+    url: https://metadata.phila.gov/#help/help-faqs/what-are-the-terms-of-use/
   - name: Other License
     url: https://opendataphilly.org/licenses/other

--- a/_data/schemas/philadelphia.yml
+++ b/_data/schemas/philadelphia.yml
@@ -20,6 +20,7 @@ dataset_fields:
   - field_name: license
     label: License
     datajson: license
+    display_template: display/license.html
   - field_name: maintainer
     label: Maintainer
     datajson: contactPoint.fn

--- a/_datasets/2009-2012-police-advisory-commission-complaints.md
+++ b/_datasets/2009-2012-police-advisory-commission-complaints.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2014-12-08T22:17:35.726140'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/311-service-and-information-requests.md
+++ b/_datasets/311-service-and-information-requests.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2016-06-22T18:26:12.844603'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: 'james.morse@phila.gov'
 maintainer_link: null

--- a/_datasets/active-residential-parking-permits-by-district.md
+++ b/_datasets/active-residential-parking-permits-by-district.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-06-02T18:32:53.895509'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/aerial-photography.md
+++ b/_datasets/aerial-photography.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Planning / Zoning
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Office of Innovation & Technology
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: null

--- a/_datasets/affordable-housing-production.md
+++ b/_datasets/affordable-housing-production.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/air-monitoring-stations.md
+++ b/_datasets/air-monitoring-stations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2015-04-24T13:46:27.485493'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/air-quality-index-days.md
+++ b/_datasets/air-quality-index-days.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2015-09-14T21:28:48.847954'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: mos@phila.gov
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/ams-latest-air-quality-sensor-readings.md
+++ b/_datasets/ams-latest-air-quality-sensor-readings.md
@@ -9,7 +9,7 @@ category:
 - Planning / Zoning
 - Public Safety
 created: '2022-05-03T18:27:22.197394'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/archived-2007-2015-litter-index.md
+++ b/_datasets/archived-2007-2015-litter-index.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2018-02-26T21:11:04.751576'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/archived-greenworks-metrics.md
+++ b/_datasets/archived-greenworks-metrics.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2016-11-10T05:47:25.073084'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/archived-philadelphia-food-access.md
+++ b/_datasets/archived-philadelphia-food-access.md
@@ -5,7 +5,7 @@ category:
 - Food
 - Health / Human Services
 created: '2016-01-19T21:20:31.167867'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/archived-planning-analysis-sections.md
+++ b/_datasets/archived-planning-analysis-sections.md
@@ -4,7 +4,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2014-12-08T21:58:18.716956'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: http://www.philaplanning.org/

--- a/_datasets/archived-valet-parking-locations.md
+++ b/_datasets/archived-valet-parking-locations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-06-02T18:23:11.387013'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/arterial-streets.md
+++ b/_datasets/arterial-streets.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T05:53:41.054908'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/big-belly-trash-bin-usage.md
+++ b/_datasets/big-belly-trash-bin-usage.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-25T17:21:24.464458'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/big-belly-waste-baskets-trash-bins.md
+++ b/_datasets/big-belly-waste-baskets-trash-bins.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Environment
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/bike-network-supporting-datasets.md
+++ b/_datasets/bike-network-supporting-datasets.md
@@ -4,7 +4,7 @@ category:
 - Parks / Recreation
 - Transportation
 created: '2014-12-08'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Streets Department
 maintainer_email: ''
 maintainer_link: http://www.phila.gov/streets/

--- a/_datasets/bike-network.md
+++ b/_datasets/bike-network.md
@@ -5,7 +5,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2014-12-08T22:33:41.160825'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Streets Department
 maintainer_email: ''
 maintainer_link: http://www.phila.gov/streets/

--- a/_datasets/boost_business.md
+++ b/_datasets/boost_business.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: 'Qadeer Gulzari'
 maintainer_email: 'qadeer.gulzari@phila.gov'
 maintainer_link: null

--- a/_datasets/bridge-locations.md
+++ b/_datasets/bridge-locations.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T04:35:02.175594'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/building-demolitions.md
+++ b/_datasets/building-demolitions.md
@@ -6,7 +6,7 @@ category:
 - Public Safety
 - Real Estate / Land Records
 created: '2017-11-02T18:34:24.957412'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/building-footprints.md
+++ b/_datasets/building-footprints.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Planning / Zoning
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: http://www.phila.gov/dot/

--- a/_datasets/bullet-voting-2015.md
+++ b/_datasets/bullet-voting-2015.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-12-07T17:44:10.144146'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/bus-shelters.md
+++ b/_datasets/bus-shelters.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Public Safety
 - Transportation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/business-improvement-districts.md
+++ b/_datasets/business-improvement-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null 
 maintainer_link: null

--- a/_datasets/business-technical-support-resources.md
+++ b/_datasets/business-technical-support-resources.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 created: '2022-08-30T17:37:40.434047'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/campaign-finance-reports.md
+++ b/_datasets/campaign-finance-reports.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Elections / Politics
 created: '2014-12-08T22:51:34.264504'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: bryan.mchale@phila.gov
 maintainer_email: bryan.mchale@phila.gov
 maintainer_link: http://www.phila.gov/records/campaignfinance/CampaignFinance.html

--- a/_datasets/candidates.md
+++ b/_datasets/candidates.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-03-17T18:10:47.674208'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 maintainer_link: null

--- a/_datasets/census-block-groups.md
+++ b/_datasets/census-block-groups.md
@@ -9,7 +9,7 @@ category:
 - Planning / Zoning
 - Public Safety
 created: '2015-06-09T18:09:19.775520'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/census-blocks.md
+++ b/_datasets/census-blocks.md
@@ -9,7 +9,7 @@ category:
 - Public Safety
 - Real Estate / Land Records
 created: '2014-12-08T21:55:04.256289'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/census-tracts.md
+++ b/_datasets/census-tracts.md
@@ -9,7 +9,7 @@ category:
 - Planning / Zoning
 - Public Safety
 created: '2015-06-09T19:36:14.934174'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/center-city-district-boundary-business-improvement-district.md
+++ b/_datasets/center-city-district-boundary-business-improvement-district.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T21:48:58.392460'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/center-city-district-police-boundary.md
+++ b/_datasets/center-city-district-police-boundary.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Public Safety
 created: '2020-09-30T20:47:49.439841'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/certified-for-rental-suitability.md
+++ b/_datasets/certified-for-rental-suitability.md
@@ -5,7 +5,7 @@ category:
 - Public Safety
 - Real Estate / Land Records
 created: '2022-09-01T14:25:07.402082'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: ligisteam@phila.gov
 maintainer_link: null

--- a/_datasets/choice-neighborhoods.md
+++ b/_datasets/choice-neighborhoods.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-02T02:57:53.351178'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mark Dodds
 maintainer_email: mark.dodds@phila.gov
 maintainer_link: null

--- a/_datasets/city-council-districts.md
+++ b/_datasets/city-council-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-08-19T22:33:38.503471'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/city-employee-earnings.md
+++ b/_datasets/city-employee-earnings.md
@@ -4,7 +4,7 @@ category:
 - Budget / Finance
 - Economy
 created: '2016-04-04T23:07:03.029842'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/city-facilities-master-facilities-database.md
+++ b/_datasets/city-facilities-master-facilities-database.md
@@ -5,7 +5,7 @@ category:
 - Parks / Recreation
 - Real Estate / Land Records
 created: '2016-01-20T16:03:45.901452'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Rich Quodomine
 maintainer_email: richard.quodomine@phila.gov
 maintainer_link: null

--- a/_datasets/city-landmarks.md
+++ b/_datasets/city-landmarks.md
@@ -4,7 +4,7 @@ category:
 - Arts / Culture / History
 - Parks / Recreation
 created: '2017-11-01T15:55:41.740923'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: maps@phila.gov
 maintainer_email: maps@phila.gov
 maintainer_link: null

--- a/_datasets/city-limits.md
+++ b/_datasets/city-limits.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Planning / Zoning
 created: '2014-12-08T22:45:50.420741'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/city-operating-budget.md
+++ b/_datasets/city-operating-budget.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Budget / Finance
 created: '2015-03-02T17:48:11.428980'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: http://www.phila.gov/finance/contact.html

--- a/_datasets/city-owned-bridges.md
+++ b/_datasets/city-owned-bridges.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-09-01T14:57:48.780192'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/city-owned-properties.md
+++ b/_datasets/city-owned-properties.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-01-30T19:40:59.857775'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: PHDC
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/city-payments.md
+++ b/_datasets/city-payments.md
@@ -14,7 +14,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2019-03-13T21:17:04.722160'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Catherine Lamb
 maintainer_email: catherine.lamb@phila.gov
 maintainer_link: null

--- a/_datasets/city-plan-boundary.md
+++ b/_datasets/city-plan-boundary.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Boundaries
 created: '2015-06-09T08:14:26.747951'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/city-registered-local-businesses.md
+++ b/_datasets/city-registered-local-businesses.md
@@ -4,7 +4,7 @@ category:
 - Budget / Finance
 - Economy
 created: '2021-05-14T12:44:05.002185'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/civil-service-positions-details.md
+++ b/_datasets/civil-service-positions-details.md
@@ -4,7 +4,7 @@ category:
 - Budget / Finance
 - Economy
 created: '2022-08-25T20:45:42.646502'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Jerome Lomax
 maintainer_email: jerome.lomax@phila.gov
 maintainer_link: null

--- a/_datasets/combined-sewer-service-area.md
+++ b/_datasets/combined-sewer-service-area.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Real Estate / Land Records
 created: '2014-12-08T22:40:36.589956'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/commercial-corridors-of-philadelphia.md
+++ b/_datasets/commercial-corridors-of-philadelphia.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2016-01-20T20:04:40.350818'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/commodities-contracts.md
+++ b/_datasets/commodities-contracts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Budget / Finance
 created: '2015-03-09T20:26:30.123356'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Office of Innovation & Technology
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/community-compost-network-site.md
+++ b/_datasets/community-compost-network-site.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Food
 created: '2021-11-30T20:06:00.668651'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Health / Human Services
 created: '2015-10-07T13:29:47.073232'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: 'epi@phila.gov'
 maintainer_link: null

--- a/_datasets/complaints-against-police.md
+++ b/_datasets/complaints-against-police.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Public Safety
 created: '2017-11-01T14:14:34.042338'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/complete-streets.md
+++ b/_datasets/complete-streets.md
@@ -4,7 +4,7 @@ category:
 - Planning / Zoning
 - Transportation
 created: '2014-12-08T22:07:56.196014'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/condom-distribution-sites.md
+++ b/_datasets/condom-distribution-sites.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2015-04-24T13:50:17.907822'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/correctional-facilities-locations.md
+++ b/_datasets/correctional-facilities-locations.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T20:24:46.113866'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/courts.md
+++ b/_datasets/courts.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T20:36:49.446397'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/covid-19-test-sites.md
+++ b/_datasets/covid-19-test-sites.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2020-09-21T11:44:46.978895'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: PublicHealthInfo@phila.gov
 maintainer_email: PublicHealthInfo@phila.gov
 maintainer_link: null

--- a/_datasets/covid-19-vaccinations.md
+++ b/_datasets/covid-19-vaccinations.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2021-02-03T14:44:35.061685'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: PublicHealthInfo@phila.gov
 maintainer_email: PublicHealthInfo@phila.gov
 maintainer_link: null

--- a/_datasets/covid-cumulative-historical-snapshots.md
+++ b/_datasets/covid-cumulative-historical-snapshots.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2020-08-09T23:26:16.351308'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Ambient Point Data Team
 maintainer_email: data@ambientpointcorp.com
 maintainer_link: null

--- a/_datasets/covid-deaths.md
+++ b/_datasets/covid-deaths.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2020-05-05T17:48:08.839201'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: PublicHealthInfo@phila.gov
 maintainer_email: PublicHealthInfo@phila.gov
 maintainer_link: null

--- a/_datasets/covid-hospitalizations.md
+++ b/_datasets/covid-hospitalizations.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2020-07-14T15:46:27.537489'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: PublicHealthInfo@phila.gov
 maintainer_email: PublicHealthInfo@phila.gov
 maintainer_link: null

--- a/_datasets/covid-tests-and-cases.md
+++ b/_datasets/covid-tests-and-cases.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2020-04-24T15:21:21.961405'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: PublicHealthInfo@phila.gov
 maintainer_email: PublicHealthInfo@phila.gov
 maintainer_link: null

--- a/_datasets/crashes.md
+++ b/_datasets/crashes.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 - Transportation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/crime-incidents.md
+++ b/_datasets/crime-incidents.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2016-04-21T22:27:16.878591'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/curbs.md
+++ b/_datasets/curbs.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Transportation
 created: '2014-12-08T22:52:01.251855'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: http://www.phila.gov/streets

--- a/_datasets/dams.md
+++ b/_datasets/dams.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-10-05T20:54:30.050561'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Larry Szarek
 maintainer_email: larry.szarek@phila.gov
 maintainer_link: null

--- a/_datasets/department-of-records-easement.md
+++ b/_datasets/department-of-records-easement.md
@@ -6,7 +6,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2015-09-01T16:02:19.223971'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/department-of-records-property-parcels.md
+++ b/_datasets/department-of-records-property-parcels.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Real Estate / Land Records
 created: '2014-12-08T21:56:54.780656'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Tracy Dandridge
 maintainer_email: tracy.dandridge@phila.gov
 maintainer_link: http://www.phila.gov/records/

--- a/_datasets/digital-elevation-model-dem.md
+++ b/_datasets/digital-elevation-model-dem.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Environment
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/district-attorney-dashboard.md
+++ b/_datasets/district-attorney-dashboard.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
  - Public Safety
 created: '2024-04-12'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: "Philadelphia District Attorney's Office DATA Lab"
 maintainer_email: ''
 maintainer_link: https://phillyda.org/data-lab/

--- a/_datasets/district-attorney.md
+++ b/_datasets/district-attorney.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2024-04-12'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: "Philadelphia District Attorney's Office DATA Lab"
 maintainer_email: ''
 maintainer_link: https://phillyda.org/data-lab/

--- a/_datasets/economic-opportunity-plans.md
+++ b/_datasets/economic-opportunity-plans.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-05-19T20:00:19.416589'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Nicholas Jann
 maintainer_email: nicholas.jann@phila.gov
 maintainer_link: null

--- a/_datasets/elected-committee-people.md
+++ b/_datasets/elected-committee-people.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-03-17T18:15:54.472986'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 maintainer_link: null

--- a/_datasets/election-board-who-worked-on-election-day.md
+++ b/_datasets/election-board-who-worked-on-election-day.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-03-17T18:21:14.123118'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 maintainer_link: null

--- a/_datasets/election-results.md
+++ b/_datasets/election-results.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Elections / Politics
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: 'vote@phila.gov'
 maintainer_link: null

--- a/_datasets/empowerment-zones.md
+++ b/_datasets/empowerment-zones.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Planning / Zoning
 created: '2014-12-08T22:30:22.412019'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/enterprise-zones.md
+++ b/_datasets/enterprise-zones.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Planning / Zoning
 created: '2014-12-08T22:50:30.915944'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/existing-trails.md
+++ b/_datasets/existing-trails.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Transportation
 - Environment
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: David Kanthor
 maintainer_email: david.kanthor@phila.gov
 maintainer_link: 

--- a/_datasets/exterior-violation-cleanups.md
+++ b/_datasets/exterior-violation-cleanups.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Real Estate / Land Records
 created: '2015-01-14T20:40:39.894443'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/farmers-markets-locations.md
+++ b/_datasets/farmers-markets-locations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Food
 created: '2014-12-08T22:15:58.147670'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/fatal-crashes.md
+++ b/_datasets/fatal-crashes.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2019-09-25T13:31:38.143475'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Captain Heinzeroth
 maintainer_email: robert.heinzeroth@phila.gov
 maintainer_link: null

--- a/_datasets/fema-flood-plain.md
+++ b/_datasets/fema-flood-plain.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-06-09T21:06:44.713244'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/fire-department-facilities.md
+++ b/_datasets/fire-department-facilities.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Public Safety
 created: '2014-12-08T22:24:29.467611'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: http://www.phila.gov/fire/

--- a/_datasets/flu-shot-clinic-schedule-and-locations.md
+++ b/_datasets/flu-shot-clinic-schedule-and-locations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2014-12-08T22:26:22.755417'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Public Health
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/free-food-sites.md
+++ b/_datasets/free-food-sites.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 category: []
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/green-stormwater-infrastructure-gsi-planning-parcels.md
+++ b/_datasets/green-stormwater-infrastructure-gsi-planning-parcels.md
@@ -5,7 +5,7 @@ category:
 - Environment
 - Real Estate / Land Records
 created: '2021-08-12T16:07:13.462234'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/green-stormwater-infrastructure-planning-districts.md
+++ b/_datasets/green-stormwater-infrastructure-planning-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-06-10T14:27:25.872719'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/green-stormwater-infrastructure-private-projects.md
+++ b/_datasets/green-stormwater-infrastructure-private-projects.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2016-05-11T17:06:36.367742'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/green-stormwater-infrastructure-public-projects.md
+++ b/_datasets/green-stormwater-infrastructure-public-projects.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2016-04-25T23:23:45.371317'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/health-centers.md
+++ b/_datasets/health-centers.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2015-01-30T16:23:42.499670'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/health-of-the-city.md
+++ b/_datasets/health-of-the-city.md
@@ -6,7 +6,7 @@ category:
 - Food
 - Health / Human Services
 created: '2023-12-20T14:04:47.073232'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: 'Philadelphia Department of Public Health'
 maintainer_email: 'epi@phila.gov'
 maintainer_link: null

--- a/_datasets/healthy-chinese-takeout.md
+++ b/_datasets/healthy-chinese-takeout.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-05-21T05:36:55.335146'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/healthy-corner-store-locations.md
+++ b/_datasets/healthy-corner-store-locations.md
@@ -4,7 +4,7 @@ category:
 - Food
 - Health / Human Services
 created: '2014-12-08T22:30:55.883782'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/healthy-start-community-resource-centers.md
+++ b/_datasets/healthy-start-community-resource-centers.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2015-04-24T13:51:21.670646'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/heat-vulnerability-by-census-tract.md
+++ b/_datasets/heat-vulnerability-by-census-tract.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Environment
 created: '2022-07-21T14:36:42.564606'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Alexandra Skula
 maintainer_email: alexandra.skula@phila.gov
 maintainer_link: null

--- a/_datasets/highway-districts.md
+++ b/_datasets/highway-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2014-12-08T22:42:15.275162'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Michael Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: http://www.phila.gov/streets

--- a/_datasets/highway-sections.md
+++ b/_datasets/highway-sections.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T07:31:26.896114'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/highway-subsections.md
+++ b/_datasets/highway-subsections.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T07:36:48.532024'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/historic-streams.md
+++ b/_datasets/historic-streams.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2016-02-17T19:46:30.866683'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/historic-streets.md
+++ b/_datasets/historic-streets.md
@@ -4,7 +4,7 @@ category:
 - Planning / Zoning
 - Transportation
 created: '2015-06-09T07:17:26.585413'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/hiv-testing-sites.md
+++ b/_datasets/hiv-testing-sites.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2021-01-29T17:24:22.489258'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/homes-saved.md
+++ b/_datasets/homes-saved.md
@@ -6,7 +6,7 @@ category:
 - Health / Human Services
 - Real Estate / Land Records
 created: '2015-12-03T14:42:25.321720'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/housing-counseling-agencies.md
+++ b/_datasets/housing-counseling-agencies.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Real Estate / Land Records
 created: '2015-11-30T20:19:08.655631'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/hydrology.md
+++ b/_datasets/hydrology.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Planning / Zoning
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: http://www.phila.gov/water/

--- a/_datasets/impervious-surfaces.md
+++ b/_datasets/impervious-surfaces.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Real Estate / Land Records
 created: '2014-12-08T22:54:44.588037'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Brian Ivey
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: http://www.phila.gov/water/

--- a/_datasets/indego-bike-share-stations.md
+++ b/_datasets/indego-bike-share-stations.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 - Transportation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/indego-bike-share-trips.md
+++ b/_datasets/indego-bike-share-trips.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 - Transportation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/instore-forgivable-loan-program.md
+++ b/_datasets/instore-forgivable-loan-program.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/intersection-controls.md
+++ b/_datasets/intersection-controls.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-09-22T18:27:21.085648'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/land-use.md
+++ b/_datasets/land-use.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Planning / Zoning
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/landcare-program.md
+++ b/_datasets/landcare-program.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Real Estate / Land Records
 created: '2015-03-16T21:19:27.744946'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/language-services-usage.md
+++ b/_datasets/language-services-usage.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Deise.Rodrigues@Phila.gov
 maintainer_email: Deise.Rodrigues@Phila.gov
 maintainer_link: null

--- a/_datasets/large-building-energy-benchmarking-data.md
+++ b/_datasets/large-building-energy-benchmarking-data.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: benchmarkinghelp@phila.gov
 maintainer_email: benchmarkinghelp@phila.gov
 maintainer_link: null

--- a/_datasets/leaf-collection-areas.md
+++ b/_datasets/leaf-collection-areas.md
@@ -5,7 +5,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2015-06-09T06:52:17.678606'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/leaf-dropoff-sites.md
+++ b/_datasets/leaf-dropoff-sites.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2020-12-21T16:36:24.081855'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-appeals-of-code-violations-and-permit-refusals.md
+++ b/_datasets/licenses-and-inspections-appeals-of-code-violations-and-permit-refusals.md
@@ -5,7 +5,7 @@ category:
 - Public Safety
 - Real Estate / Land Records
 created: '2016-09-22T14:01:30.276425'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-building-and-zoning-permits.md
+++ b/_datasets/licenses-and-inspections-building-and-zoning-permits.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: []
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: LIGISTEAM@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-building-certifications.md
+++ b/_datasets/licenses-and-inspections-building-certifications.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Real Estate / Land Records
 created: '2021-08-16T18:17:51.426775'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-business-licenses.md
+++ b/_datasets/licenses-and-inspections-business-licenses.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2016-09-22T21:14:38.869844'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-case-investigations.md
+++ b/_datasets/licenses-and-inspections-case-investigations.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2016-09-22T16:17:08.376879'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-clean-and-seal.md
+++ b/_datasets/licenses-and-inspections-clean-and-seal.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2016-09-22T18:07:28.682465'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-code-violations.md
+++ b/_datasets/licenses-and-inspections-code-violations.md
@@ -4,7 +4,7 @@ category:
 - Public Safety
 - Real Estate / Land Records
 created: '2015-05-27T17:25:21.594800'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: LIGISTEAM@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-commercial-activity-licenses.md
+++ b/_datasets/licenses-and-inspections-commercial-activity-licenses.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 created: '2016-09-22T15:36:26.156628'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-complaints.md
+++ b/_datasets/licenses-and-inspections-complaints.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2016-09-22T14:31:12.542396'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-district-offices.md
+++ b/_datasets/licenses-and-inspections-district-offices.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2019-08-06T13:29:46.242146'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Department of Licenses and Inspections
 maintainer_email: ligisteam@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-districts.md
+++ b/_datasets/licenses-and-inspections-districts.md
@@ -5,7 +5,7 @@ category:
 - Economy
 - Real Estate / Land Records
 created: '2015-01-30T19:27:53.322578'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Department of Licenses and Inspections
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-property-history.md
+++ b/_datasets/licenses-and-inspections-property-history.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Real Estate / Land Records
 created: '2023-08-04T16:03:32.745793'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/licenses-and-inspections-trade-licenses.md
+++ b/_datasets/licenses-and-inspections-trade-licenses.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2016-09-22T21:15:57.272811'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: LIGISTEAM@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/lidar-las-data.md
+++ b/_datasets/lidar-las-data.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Environment
 created: '2014-12-08T22:08:29.229053'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Office of Innovation & Technology
 maintainer_email: maps@phila.gov
 maintainer_link: null

--- a/_datasets/litter-index.md
+++ b/_datasets/litter-index.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2015-01-16T16:46:17.148739'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: cleanphl@phila.gov
 maintainer_email: cleanphl@phila.gov
 maintainer_link: null

--- a/_datasets/major-watersheds-philadelphia.md
+++ b/_datasets/major-watersheds-philadelphia.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2014-12-08T22:37:04.627199'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/major-watersheds-regional.md
+++ b/_datasets/major-watersheds-regional.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2015-09-11T18:51:40.249272'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/market-value-assessment.md
+++ b/_datasets/market-value-assessment.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/neighborhood-advisory-committees-nacs.md
+++ b/_datasets/neighborhood-advisory-committees-nacs.md
@@ -4,7 +4,7 @@ category:
 - Arts / Culture / History
 - Health / Human Services
 created: '2015-11-30T20:33:33.224755'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Portia Egan
 maintainer_email: portia.egan@phila.gov
 maintainer_link: null

--- a/_datasets/neighborhood-energy-centers.md
+++ b/_datasets/neighborhood-energy-centers.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2019-05-22T17:46:14.482318'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Portia Egan
 maintainer_email: portia.egan@phila.gov
 maintainer_link: null

--- a/_datasets/neighborhood-food-retail.md
+++ b/_datasets/neighborhood-food-retail.md
@@ -5,7 +5,7 @@ category:
 - Food
 - Health / Human Services
 created: '2019-08-26T14:11:24.194581'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/neighborhood-resources.md
+++ b/_datasets/neighborhood-resources.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Planning / Zoning
 created: '2020-12-16T19:31:17.799665'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/non-thru-streets-for-trucks.md
+++ b/_datasets/non-thru-streets-for-trucks.md
@@ -6,7 +6,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2015-06-09T06:45:40.213255'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/oeo-registry-of-certified-minoritywomendisable-owned-business-enterprises.md
+++ b/_datasets/oeo-registry-of-certified-minoritywomendisable-owned-business-enterprises.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 created: '2015-01-21T19:19:30.024943'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/openmaps.md
+++ b/_datasets/openmaps.md
@@ -17,7 +17,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2018-04-30T13:27:10.098614'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: CityGeo
 maintainer_email: maps@phila.gov
 maintainer_link: null

--- a/_datasets/outdoor-advertising.md
+++ b/_datasets/outdoor-advertising.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2016-04-25T22:09:17.756565'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/parking-meter-kiosk-inventory.md
+++ b/_datasets/parking-meter-kiosk-inventory.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-01-21T14:17:47.544851'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/parking-violations.md
+++ b/_datasets/parking-violations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-05-19T17:28:13.384290'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/parks-and-recreation-out-of-school-time-programs.md
+++ b/_datasets/parks-and-recreation-out-of-school-time-programs.md
@@ -4,7 +4,7 @@ category:
 - Parks / Recreation
 - Education
 created: '2015-05-22T04:58:38.912312'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/parks-and-recreation-ppr-trails.md
+++ b/_datasets/parks-and-recreation-ppr-trails.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Parks / Recreation
 created: '2014-12-08T22:48:52.339357'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/parks-recreation-districts.md
+++ b/_datasets/parks-recreation-districts.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Parks / Recreation
 created: '2015-01-16T16:37:08.456601'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Parks & Recreation
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/parks-recreation-program-sites.md
+++ b/_datasets/parks-recreation-program-sites.md
@@ -6,7 +6,7 @@ category:
 - Parks / Recreation
 - Public Safety
 created: '2022-03-02T18:33:33.321745'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/paving-plan.md
+++ b/_datasets/paving-plan.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-05-28T13:48:07.346672'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/pennsylvania-state-house-of-representatives-districts.md
+++ b/_datasets/pennsylvania-state-house-of-representatives-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-06-15T19:13:05.103858'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/people-released-to-philadelphia-from-prison-jail.md
+++ b/_datasets/people-released-to-philadelphia-from-prison-jail.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Public Safety
 created: '2018-03-08T20:43:51.618312'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Aviva Tevah
 maintainer_email: Aviva.Tevah@Phila.gov
 maintainer_link: null

--- a/_datasets/percent-for-art-locations.md
+++ b/_datasets/percent-for-art-locations.md
@@ -6,7 +6,7 @@ category:
 - Health / Human Services
 - Planning / Zoning
 created: '2020-07-02T20:13:46.923823'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dan Whaland
 maintainer_email: daniel.whaland@phila.gov
 maintainer_link: null

--- a/_datasets/pha-housing-sites.md
+++ b/_datasets/pha-housing-sites.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Real Estate / Land Records
 created: '2014-12-08T22:03:35.055765'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: info@pha.phila.gov
 maintainer_link: http://www.pha.phila.gov/contact-us/contact-us.aspx

--- a/_datasets/philadelphia-basemaps.md
+++ b/_datasets/philadelphia-basemaps.md
@@ -4,7 +4,7 @@ category:
 - Basemaps
 - Boundaries
 created: '2014-12-08T21:58:43.438282'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: maps@phila.gov
 maintainer_email: maps@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-beverage-tax-registered-distributors-and-dealers.md
+++ b/_datasets/philadelphia-beverage-tax-registered-distributors-and-dealers.md
@@ -6,7 +6,7 @@ category:
 - Food
 - Health / Human Services
 created: '2019-10-08T18:23:41.220926'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Rebecca Lopez-Kriss
 maintainer_email: rebecca.lopezkriss@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-child-blood-lead-levels.md
+++ b/_datasets/philadelphia-child-blood-lead-levels.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Public Safety
 created: '2017-09-29T14:10:55.762595'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/philadelphia-code-and-home-rule-charter.md
+++ b/_datasets/philadelphia-code-and-home-rule-charter.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2014-12-08T22:34:39.738497'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/philadelphia-esl-english-as-a-second-language-class-locations.md
+++ b/_datasets/philadelphia-esl-english-as-a-second-language-class-locations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category: 
 - Education
 created: '2017-06-05T13:45:27.838672'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Office of Adult Education
 maintainer_email: catherine.freimiller@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-hospitals.md
+++ b/_datasets/philadelphia-hospitals.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2014-12-08T22:25:05.490132'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/philadelphia-household-internet-assessment-survey.md
+++ b/_datasets/philadelphia-household-internet-assessment-survey.md
@@ -5,7 +5,7 @@ category:
 - Education
 - Health / Human Services
 created: '2022-09-21T12:26:59.144264'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Juliet Fink-Yates
 maintainer_email: juliet.fink-yates@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-land-cover-raster.md
+++ b/_datasets/philadelphia-land-cover-raster.md
@@ -4,7 +4,7 @@ category:
 - Parks / Recreation
 - Planning / Zoning
 created: '2014-12-08T21:53:34.729974'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-lobbying-information-system-app.md
+++ b/_datasets/philadelphia-lobbying-information-system-app.md
@@ -3,7 +3,7 @@ area_of_interest: Lobbying
 category:
 - Elections / Politics
 created: '2014-12-08T22:42:43.677672'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: Lobbying@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-pennsylvania-state-senatorial-districts.md
+++ b/_datasets/philadelphia-pennsylvania-state-senatorial-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-06-15T18:35:47.279386'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/philadelphia-police-complaint-archive.md
+++ b/_datasets/philadelphia-police-complaint-archive.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2018-03-25T22:50:41.004949'
-license: Other (Public Domain)
+license: License Not Specified
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/philadelphia-properties-and-assessment-history.md
+++ b/_datasets/philadelphia-properties-and-assessment-history.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Real Estate / Land Records
 created: '2015-08-21T15:39:23.714944'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: opadata@phila.gov
 maintainer_email: opadata@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-registered-historic-districts.md
+++ b/_datasets/philadelphia-registered-historic-districts.md
@@ -6,7 +6,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2017-08-16T14:02:49.016879'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-registered-historic-properties.md
+++ b/_datasets/philadelphia-registered-historic-properties.md
@@ -6,7 +6,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2014-12-08T21:51:59.418960'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/philadelphia-tree-inventory.md
+++ b/_datasets/philadelphia-tree-inventory.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 - Parks / Recreation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: Chris.Park@Phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-universities-and-colleges.md
+++ b/_datasets/philadelphia-universities-and-colleges.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Education
 created: '2017-06-22T13:16:48.459471'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/philadelphia-vital-statistics-mortality-deaths.md
+++ b/_datasets/philadelphia-vital-statistics-mortality-deaths.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Philadelphia Department of Public Health
 maintainer_email: epi@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-vital-statistics-natality-births.md
+++ b/_datasets/philadelphia-vital-statistics-natality-births.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Philadelphia Department of Public Health
 maintainer_email: epi@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-vital-statistics-population-metrics.md
+++ b/_datasets/philadelphia-vital-statistics-population-metrics.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Philadelphia Department of Public Health
 maintainer_email: epi@phila.gov
 maintainer_link: null

--- a/_datasets/philadelphia-vital-statistics-social-determinants-of-health-sdoh.md
+++ b/_datasets/philadelphia-vital-statistics-social-determinants-of-health-sdoh.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: epi@phila.gov
 maintainer_email: epi@phila.gov
 maintainer_link: null

--- a/_datasets/philadox-property-documents.md
+++ b/_datasets/philadox-property-documents.md
@@ -3,7 +3,7 @@ area_of_interest: 'City of Philadelphia '
 category:
 - Real Estate / Land Records
 created: '2014-12-08T22:42:28.661091'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: philadox.support@phila.gov
 maintainer_link: http://www.phila.gov/records/

--- a/_datasets/philly-freight-finder.md
+++ b/_datasets/philly-freight-finder.md
@@ -4,7 +4,7 @@ area_of_interest: Delaware Valley (Camden; Gloucester; Mercer; Bucks; Chester; D
 category:
 - Transportation
 created: '2016-08-15T17:19:42.213814'
-license: Other (Open)
+license: License Not Specified
 maintainer: Sean Lawrence
 maintainer_email: slawrence@dvrpc.org
 maintainer_link: null

--- a/_datasets/philly-rising-boundaries.md
+++ b/_datasets/philly-rising-boundaries.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Health / Human Services
 created: '2014-12-08T22:04:14.942294'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Brian Ivey
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: http://www.phila.gov/mdo/phillyrising

--- a/_datasets/phillyhistoryorg.md
+++ b/_datasets/phillyhistoryorg.md
@@ -5,7 +5,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2014-12-08T22:11:26.185443'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: info@phillyhistory.org
 maintainer_link: http://www.phillyhistory.org

--- a/_datasets/phlmaps.md
+++ b/_datasets/phlmaps.md
@@ -17,7 +17,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2018-04-30T16:07:10.734070'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: CityGeo
 maintainer_email: maps@phila.gov
 maintainer_link: null

--- a/_datasets/piers.md
+++ b/_datasets/piers.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: LIGISTEAM@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null

--- a/_datasets/planning-districts.md
+++ b/_datasets/planning-districts.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Planning / Zoning
 created: '2014-12-08T22:48:17.066907'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/playstreets-locations.md
+++ b/_datasets/playstreets-locations.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2020-09-24T18:53:23.511759'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/police-athletic-league-pal-centers.md
+++ b/_datasets/police-athletic-league-pal-centers.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Parks / Recreation
 created: '2014-12-08T22:32:44.706340'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/police-districts.md
+++ b/_datasets/police-districts.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Public Safety
 created: '2014-12-08T22:12:33.763737'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: http://www.phillypolice.com/

--- a/_datasets/police-divisions.md
+++ b/_datasets/police-divisions.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Public Safety
 created: '2014-12-08T22:55:37.589873'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/police-service-areas.md
+++ b/_datasets/police-service-areas.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Public Safety
 created: '2014-12-08T22:34:27.848090'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/police-stations.md
+++ b/_datasets/police-stations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2015-01-30T17:32:47.980292'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/political-ward-divisions.md
+++ b/_datasets/political-ward-divisions.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Elections / Politics
 created: '2014-12-08T22:56:02.445787'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: Darshna.Patel@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/political-wards.md
+++ b/_datasets/political-wards.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Elections / Politics
 created: '2014-12-08T22:53:33.227657'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://www.philaplanning.org/

--- a/_datasets/polling-places.md
+++ b/_datasets/polling-places.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Elections / Politics
 created: '2014-12-08T22:26:32.294770'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 maintainer_link: "www.philadelphiavotes.com/\u200E"

--- a/_datasets/ppr-adult-exercise-equipment.md
+++ b/_datasets/ppr-adult-exercise-equipment.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2019-06-18T15:51:31.276548'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-boat-launches.md
+++ b/_datasets/ppr-boat-launches.md
@@ -4,7 +4,7 @@ category:
 - Parks / Recreation
 - Transportation
 created: '2015-01-14T21:31:23.917614'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Parks & Recreation
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/ppr-building-structures.md
+++ b/_datasets/ppr-building-structures.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2020-08-26T15:57:56.902203'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-friends-group.md
+++ b/_datasets/ppr-friends-group.md
@@ -5,7 +5,7 @@ category:
 - Parks / Recreation
 - Planning / Zoning
 created: '2019-08-26T17:59:57.415901'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-help-locators.md
+++ b/_datasets/ppr-help-locators.md
@@ -5,7 +5,7 @@ category:
   - Health / Human Services
   - Parks / Recreation
 created: '2019-06-18T15:51:31.276548'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-hydration-stations.md
+++ b/_datasets/ppr-hydration-stations.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2019-04-05T18:39:30.196007'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-permittable-space.md
+++ b/_datasets/ppr-permittable-space.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2020-01-29T21:11:25.970210'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Andy Viren
 maintainer_email: andy.viren@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-picnic-sites.md
+++ b/_datasets/ppr-picnic-sites.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2019-06-18T15:26:54.259554'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-playgrounds.md
+++ b/_datasets/ppr-playgrounds.md
@@ -5,7 +5,7 @@ category:
 - Parks / Recreation
 - Real Estate / Land Records
 created: '2020-01-29T20:24:59.915600'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-program-districts.md
+++ b/_datasets/ppr-program-districts.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Health / Human Services
 - Parks / Recreation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/ppr-properties.md
+++ b/_datasets/ppr-properties.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2020-01-29T20:30:49.330744'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-spraygrounds.md
+++ b/_datasets/ppr-spraygrounds.md
@@ -5,7 +5,7 @@ category:
 - Parks / Recreation
 - Planning / Zoning
 created: '2019-08-26T17:59:57.415901'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-swimming-pools.md
+++ b/_datasets/ppr-swimming-pools.md
@@ -5,7 +5,7 @@ category:
 - Parks / Recreation
 - Planning / Zoning
 created: '2019-08-26T18:31:03.560839'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-tennis-courts.md
+++ b/_datasets/ppr-tennis-courts.md
@@ -4,7 +4,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2019-06-18T15:06:01.708170'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/ppr-tree-canopy.md
+++ b/_datasets/ppr-tree-canopy.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2019-04-05T19:20:58.225402'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/prep-providers.md
+++ b/_datasets/prep-providers.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2021-01-29T17:01:49.626615'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/professional-services-contracts.md
+++ b/_datasets/professional-services-contracts.md
@@ -4,7 +4,7 @@ category:
 - Budget / Finance
 - Economy
 created: '2014-12-08T22:38:54.946558'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: T. David Williams
 maintainer_email: t.david.williams@phila.gov
 maintainer_link: null

--- a/_datasets/pwd-customer-service-calls.md
+++ b/_datasets/pwd-customer-service-calls.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-10-15T02:19:34.441360'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Angeline Zamorski
 maintainer_email: angeline.zamorski@phila.gov
 maintainer_link: null

--- a/_datasets/pwd-geotechnical-tests.md
+++ b/_datasets/pwd-geotechnical-tests.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2022-11-28T22:53:18.634544'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: larry.szarek@phila.gov
 maintainer_email: larry.szarek@phila.gov
 maintainer_link: null

--- a/_datasets/pwd-sewersheds.md
+++ b/_datasets/pwd-sewersheds.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Planning / Zoning
 created: '2019-11-26T17:13:06.948288'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Raymond Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/pwd-stormwater-billing-parcels.md
+++ b/_datasets/pwd-stormwater-billing-parcels.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 - Real Estate/Land 
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/pwd-stream-sampling-locations.md
+++ b/_datasets/pwd-stream-sampling-locations.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Public Safety
 created: '2015-10-14T16:40:42.512184'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Raymond Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/railroad-lines.md
+++ b/_datasets/railroad-lines.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T16:46:39.219713'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Brian Ivey
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: null

--- a/_datasets/rain-barrels.md
+++ b/_datasets/rain-barrels.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-09-14T18:29:03.311187'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/rain-check-installation-sites.md
+++ b/_datasets/rain-check-installation-sites.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-10-14T17:45:31.340108'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/rain-gauges.md
+++ b/_datasets/rain-gauges.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-10-07T17:42:05.363372'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Edward Lennon, Jr.
 maintainer_email: edward.lennonjr@phila.gov
 maintainer_link: null

--- a/_datasets/real-estate-tax-balances.md
+++ b/_datasets/real-estate-tax-balances.md
@@ -4,7 +4,7 @@ category:
 - Budget / Finance
 - Economy
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Roman Strakovsky
 maintainer_email: 	roman.strakovsky@phila.gov
 maintainer_link: null

--- a/_datasets/real-estate-transfers.md
+++ b/_datasets/real-estate-transfers.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2018-01-31T15:35:22.145778'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Alex Waldman
 maintainer_email: alex.waldman@phila.gov
 maintainer_link: null

--- a/_datasets/recyclebank-participation.md
+++ b/_datasets/recyclebank-participation.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-01-16T16:50:27.315346'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/recycling-diversion-rate.md
+++ b/_datasets/recycling-diversion-rate.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/recycling-donations-resources.md
+++ b/_datasets/recycling-donations-resources.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 category: []
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/red-light-cameras.md
+++ b/_datasets/red-light-cameras.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2014-12-08T22:17:19.277559'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/redevelopment-certified-areas.md
+++ b/_datasets/redevelopment-certified-areas.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2014-12-08T22:20:25.463531'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: http://www.philaplanning.org/

--- a/_datasets/registered-community-gardens.md
+++ b/_datasets/registered-community-gardens.md
@@ -6,7 +6,7 @@ category:
 - Health / Human Services
 - Parks / Recreation
 created: '2021-11-30T18:24:50.362574'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/registered-community-organizations-rco-boundaries.md
+++ b/_datasets/registered-community-organizations-rco-boundaries.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Planning / Zoning
 created: '2014-12-08T22:29:11.464086'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Pauline Loughlin
 maintainer_email: pauline.loughlin@phila.gov
 maintainer_link: null

--- a/_datasets/residency-waivers.md
+++ b/_datasets/residency-waivers.md
@@ -4,7 +4,7 @@ category:
 - Budget / Finance
 - Economy
 created: '2022-08-26T12:24:44.345925'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Jerome Lomax
 maintainer_email: jerome.lomax@phila.gov
 maintainer_link: null

--- a/_datasets/residential-parking-permit-blocks.md
+++ b/_datasets/residential-parking-permit-blocks.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-06-02T18:35:01.828590'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/retrofitted-homes.md
+++ b/_datasets/retrofitted-homes.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-09-15T17:40:10.575133'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: mos@phila.gov
 maintainer_email: http://metadata.phila.gov/#home/datasetdetails/55f6dd9fb22cc14e01e7ec68/representationdetails/55f8574226c3115b5533017c/
 maintainer_link: null

--- a/_datasets/ryan-white-hiv-treatment-centers.md
+++ b/_datasets/ryan-white-hiv-treatment-centers.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2015-04-24T13:52:21.286438'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/sanitation-areas.md
+++ b/_datasets/sanitation-areas.md
@@ -6,7 +6,7 @@ category:
 - Health / Human Services
 - Planning / Zoning
 created: '2014-12-08T22:49:48.724091'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: http://www.phila.gov/streets

--- a/_datasets/sanitation-collection-day-boundary.md
+++ b/_datasets/sanitation-collection-day-boundary.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T03:42:41.970072'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/sanitation-convenience-centers.md
+++ b/_datasets/sanitation-convenience-centers.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Health / Human Services
 created: '2021-12-07T21:38:50.627613'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/sanitation-districts.md
+++ b/_datasets/sanitation-districts.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Boundaries
 created: '2014-12-08T22:02:45.194282'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: http://www.phila.gov/streets/

--- a/_datasets/schools-parcels.md
+++ b/_datasets/schools-parcels.md
@@ -2,7 +2,7 @@
 area_of_interest: City of Philadelphia
 category:
 - Education
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://philaplanning.org/

--- a/_datasets/schools.md
+++ b/_datasets/schools.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Education
 created: '2014-12-08T21:57:28.065312'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://philaplanning.org/

--- a/_datasets/sharps-drop-boxes.md
+++ b/_datasets/sharps-drop-boxes.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Health / Human Services
 created: '2021-01-29T17:15:05.779170'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/shooting-victims.md
+++ b/_datasets/shooting-victims.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2016-04-21T22:38:08.194327'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/snow-emergency-routes.md
+++ b/_datasets/snow-emergency-routes.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-01-16T16:57:46.359102'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/special-vending-districts.md
+++ b/_datasets/special-vending-districts.md
@@ -7,7 +7,7 @@ category:
 - Food
 - Planning / Zoning
 created: '2015-09-01T17:35:27.182500'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: 'ligisteam@phila.gov '
 maintainer_email: ligisteam@phila.gov
 maintainer_link: null

--- a/_datasets/storefront-improvement-program-grants-disbursed.md
+++ b/_datasets/storefront-improvement-program-grants-disbursed.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Real Estate / Land Records
 created: '2015-05-19T20:19:20.668577'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/stormwater-management-practice-polygons.md
+++ b/_datasets/stormwater-management-practice-polygons.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-10-07T18:24:09.439881'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/stormwater-outfalls.md
+++ b/_datasets/stormwater-outfalls.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Environment
 created: '2015-10-07T16:04:20.089184'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/street-centerlines-for-vision-zero-high-injury-network-2017.md
+++ b/_datasets/street-centerlines-for-vision-zero-high-injury-network-2017.md
@@ -4,7 +4,7 @@ category:
 - Public Safety
 - Transportation
 created: '2017-10-02T18:20:34.562755'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/street-centerlines.md
+++ b/_datasets/street-centerlines.md
@@ -4,7 +4,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 - Transportation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: http://www.phila.gov/streets/

--- a/_datasets/street-lane-closure-emergency-utility-network.md
+++ b/_datasets/street-lane-closure-emergency-utility-network.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-06-09T07:08:34.582261'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/street-lane-closures.md
+++ b/_datasets/street-lane-closures.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2014-12-08T22:39:10.474966'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/street-legal-cards.md
+++ b/_datasets/street-legal-cards.md
@@ -8,7 +8,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2022-06-07T21:28:11.853031'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/street-name-alias-list.md
+++ b/_datasets/street-name-alias-list.md
@@ -4,7 +4,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 created: '2015-09-22T15:39:56.329223'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/street-nodes.md
+++ b/_datasets/street-nodes.md
@@ -5,7 +5,7 @@ category:
 - Planning / Zoning
 - Real Estate / Land Records
 - Transportation
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/street-place-names.md
+++ b/_datasets/street-place-names.md
@@ -6,7 +6,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2015-09-22T15:46:11.217666'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/street-poles.md
+++ b/_datasets/street-poles.md
@@ -6,7 +6,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2015-06-09T06:03:43.125022'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/street-smart-phl.md
+++ b/_datasets/street-smart-phl.md
@@ -3,7 +3,7 @@ area_of_interest: Philadelphia
 category:
 - Transportation
 created: '2024-04-12T22:13:13'
-license: 	Other (City of Philadelphia)
+license: Other (City of Philadelphia)
 maintainer: "Streets Department"
 maintainer_email: 
 maintainer_link: https://www.phila.gov/departments/department-of-streets/

--- a/_datasets/street-smart-phl.md
+++ b/_datasets/street-smart-phl.md
@@ -3,7 +3,7 @@ area_of_interest: Philadelphia
 category:
 - Transportation
 created: '2024-04-12T22:13:13'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: "Streets Department"
 maintainer_email: 
 maintainer_link: https://www.phila.gov/departments/department-of-streets/

--- a/_datasets/streets-code-violation-notices.md
+++ b/_datasets/streets-code-violation-notices.md
@@ -4,7 +4,7 @@ category:
 - Environment
 - Real Estate / Land Records
 created: '2015-01-21T04:06:46.553387'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/streets-composite-layer.md
+++ b/_datasets/streets-composite-layer.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2019-11-04T20:11:28.659833'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/taking-care-of-business.md
+++ b/_datasets/taking-care-of-business.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Economy
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null 
 maintainer_link: null

--- a/_datasets/tobacco-free-school-zones.md
+++ b/_datasets/tobacco-free-school-zones.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Education
 - Health / Human Services
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: null
 maintainer_email: null
 maintainer_link: null

--- a/_datasets/tobacco-retailer-density-caps.md
+++ b/_datasets/tobacco-retailer-density-caps.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: []
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: epi@phila.gov
 maintainer_email: epi@phila.gov
 maintainer_link: null

--- a/_datasets/tobacco-retailer-permits.md
+++ b/_datasets/tobacco-retailer-permits.md
@@ -4,7 +4,7 @@ category:
 - Economy
 - Health / Human Services
 created: '2019-11-27T14:45:38.457626'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/topographic-contours.md
+++ b/_datasets/topographic-contours.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Environment
 created: '2014-12-08T22:22:40.010029'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: brian.ivey@phila.gov
 maintainer_link: http://www.phila.gov/water

--- a/_datasets/track-streets.md
+++ b/_datasets/track-streets.md
@@ -4,7 +4,7 @@ category:
 - Planning / Zoning
 - Transportation
 created: '2015-09-21T16:37:09.733341'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: null

--- a/_datasets/traffic-calming.md
+++ b/_datasets/traffic-calming.md
@@ -5,7 +5,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2023-27-10T22:09:40.503423'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: http://www.phila.gov/streets/

--- a/_datasets/traffic-districts.md
+++ b/_datasets/traffic-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Transportation
 created: '2015-06-09T05:14:12.280148'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/traffic-preventative-maintenance-districts.md
+++ b/_datasets/traffic-preventative-maintenance-districts.md
@@ -6,7 +6,7 @@ category:
 - Real Estate / Land Records
 - Transportation
 created: '2015-06-09T05:19:35.311377'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 maintainer_link: null

--- a/_datasets/urban-agriculture-projects.md
+++ b/_datasets/urban-agriculture-projects.md
@@ -5,7 +5,7 @@ category:
 - Food
 - Parks / Recreation
 created: '2021-11-17T14:32:56.641423'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 maintainer_link: null

--- a/_datasets/us-congressional-districts.md
+++ b/_datasets/us-congressional-districts.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Elections / Politics
 created: '2015-06-15T19:34:33.149049'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/vacant-lot-cleanups.md
+++ b/_datasets/vacant-lot-cleanups.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Real Estate / Land Records
 created: '2015-01-14T21:19:00.141192'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/vacant-property-indicators-percentage-by-block.md
+++ b/_datasets/vacant-property-indicators-percentage-by-block.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2017-03-08T17:08:45.582983'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: maps@phila.gov 
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/vacant-property-indicators.md
+++ b/_datasets/vacant-property-indicators.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2016-11-14T17:46:54.215540'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: maps@phila.gov
 maintainer_link: null

--- a/_datasets/vehicle-pedestrian-investigations.md
+++ b/_datasets/vehicle-pedestrian-investigations.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Public Safety
 created: '2016-04-21T22:08:24.449402'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null

--- a/_datasets/vending-prohibited-areas.md
+++ b/_datasets/vending-prohibited-areas.md
@@ -7,7 +7,7 @@ category:
 - Food
 - Planning / Zoning
 created: '2015-09-02T19:46:51.028464'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: ligisteam@phila.gov
 maintainer_link: null

--- a/_datasets/vending-prohibited-streets.md
+++ b/_datasets/vending-prohibited-streets.md
@@ -6,7 +6,7 @@ category:
 - Food
 - Planning / Zoning
 created: '2015-01-21T03:56:30.894181'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: ligisteam@phila.gov
 maintainer_link: null

--- a/_datasets/vending-prohibition-exceptions.md
+++ b/_datasets/vending-prohibition-exceptions.md
@@ -6,7 +6,7 @@ category:
 - Food
 - Planning / Zoning
 created: '2023-06-30T03:56:30.894181'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ligisteam@phila.gov
 maintainer_email: ligisteam@phila.gov
 maintainer_link: null

--- a/_datasets/vision-zero-high-injury-network.md
+++ b/_datasets/vision-zero-high-injury-network.md
@@ -7,7 +7,7 @@ category:
 - Public Safety
 - Transportation
 created: '2017-10-02T18:07:13.814790'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/voter-turnout.md
+++ b/_datasets/voter-turnout.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Elections / Politics
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: City Commissioner's Office
 maintainer_email: vote@phila.gov
 maintainer_link: null

--- a/_datasets/water-department-grants-disbursed.md
+++ b/_datasets/water-department-grants-disbursed.md
@@ -3,7 +3,7 @@ area_of_interest: Grants
 category:
 - Environment
 created: '2014-12-08T22:47:01.762609'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/water-inlets.md
+++ b/_datasets/water-inlets.md
@@ -3,7 +3,7 @@ area_of_interest: City of Philadelphia
 category:
 - Environment
 created: '2014-12-08T22:15:36.513147'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Larry Szarek
 maintainer_email: Larry.Szarek@phila.gov
 maintainer_link: null

--- a/_datasets/watercourses-designated-for-protection.md
+++ b/_datasets/watercourses-designated-for-protection.md
@@ -5,7 +5,7 @@ category:
 - Health / Human Services
 - Planning / Zoning
 created: '2015-01-21T15:14:44.855872'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 maintainer_link: null

--- a/_datasets/west-philadelphia-promise-zone.md
+++ b/_datasets/west-philadelphia-promise-zone.md
@@ -6,7 +6,7 @@ category:
 - Health / Human Services
 - Planning / Zoning
 created: '2015-02-26T17:33:19.437078'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/wire-waste-baskets-trash-bins.md
+++ b/_datasets/wire-waste-baskets-trash-bins.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-03-30T06:06:05.081202'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: 'Max Steinbrenner '
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null

--- a/_datasets/women-infants-children-wic-offices.md
+++ b/_datasets/women-infants-children-wic-offices.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-05-22T06:59:01.300783'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''
 maintainer_link: null

--- a/_datasets/world-meeting-of-families-authorized-vehicle-route.md
+++ b/_datasets/world-meeting-of-families-authorized-vehicle-route.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-09-10T16:10:13.993575'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: OEM
 maintainer_email: oem@phila.gov
 maintainer_link: null

--- a/_datasets/world-meeting-of-families-secure-perimeter.md
+++ b/_datasets/world-meeting-of-families-secure-perimeter.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-08-28T19:32:20.815955'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: OEM
 maintainer_email: oem@phila.gov
 maintainer_link: null

--- a/_datasets/world-meeting-of-families-secure-vehicle-perimeter.md
+++ b/_datasets/world-meeting-of-families-secure-vehicle-perimeter.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-08-28T19:39:26.758449'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: OEM
 maintainer_email: oem@phila.gov
 maintainer_link: null

--- a/_datasets/world-meeting-of-families-traffic-box.md
+++ b/_datasets/world-meeting-of-families-traffic-box.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: []
 created: '2015-08-19T13:53:00.447412'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: OEM
 maintainer_email: oem@phila.gov
 maintainer_link: null

--- a/_datasets/zip-codes.md
+++ b/_datasets/zip-codes.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Boundaries
 created: '2014-12-08T22:19:07.861855'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: http://www.philaplanning.org

--- a/_datasets/zoning-base-districts.md
+++ b/_datasets/zoning-base-districts.md
@@ -4,7 +4,7 @@ category:
 - Boundaries
 - Planning / Zoning
 - Real Estate / Land Records
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: http://www.phila.gov/cityplanning

--- a/_datasets/zoning-overlays.md
+++ b/_datasets/zoning-overlays.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Planning / Zoning
 created: '2015-08-19T14:41:17.540141'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_datasets/zoning-steep-slope-protected-area.md
+++ b/_datasets/zoning-steep-slope-protected-area.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category:
 - Planning / Zoning
 created: '2015-06-10T14:56:17.700573'
-license: Other (City of Philadelphia)
+license: City of Philadelphia License
 maintainer: 'Darshna Patel '
 maintainer_email: darshna.patel@phila.gov
 maintainer_link: null

--- a/_includes/display/license.html
+++ b/_includes/display/license.html
@@ -1,0 +1,8 @@
+{% assign licenses = site.data.licenses %}
+{% assign license_model = licenses.items | find: "name", include.value %}
+{% assign license_url = license_model.url %}
+<tr>
+  <th>{{ include.field.label }}</th>
+  <td>
+      <a href="{{ license_url }}">{{ include.value }}</a>
+  </td>

--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+{% assign datasets = site.datasets | where:"license", page.title %}
+{% assign datasets_count = datasets | size %}
+
+<div class="container">
+    <div class="row">
+        <h1>
+          {{ page.title }}
+        </h1>
+        <p>{{ page.body | markdownify }}</p>
+    </div>
+</div>
+</div>

--- a/_licenses/city-of-philadelphia.md
+++ b/_licenses/city-of-philadelphia.md
@@ -1,7 +1,0 @@
----
-title: City of Philadelphia License
-layout: license 
-permalink: /licenses/city-of-philadelphia/
-body: The City of Philadelphia reserves all rights in the City's databases and any data contained therein, and the end user’s use of the data does not constitute a transfer of, nor does the end user receive, any title or interest in the database or any other City data. The City of Philadelphia makes no representation about the accuracy of any specific information in this data and is provided “as is” and without Warranty of any kind. The user of this data will assume complete responsibility for any and all occurrences resulting from its use or display and will hold the City of Philadelphia harmless from any and all claims, demands, liabilities, obligations, damages, suits, judgments or settlements, including reasonable costs and attorneys' fees, that arise from use of this data.
----
-

--- a/_licenses/city-of-philadelphia.md
+++ b/_licenses/city-of-philadelphia.md
@@ -1,0 +1,7 @@
+---
+title: City of Philadelphia License
+layout: license 
+permalink: /licenses/city-of-philadelphia/
+body: The City of Philadelphia reserves all rights in the City's databases and any data contained therein, and the end user’s use of the data does not constitute a transfer of, nor does the end user receive, any title or interest in the database or any other City data. The City of Philadelphia makes no representation about the accuracy of any specific information in this data and is provided “as is” and without Warranty of any kind. The user of this data will assume complete responsibility for any and all occurrences resulting from its use or display and will hold the City of Philadelphia harmless from any and all claims, demands, liabilities, obligations, damages, suits, judgments or settlements, including reasonable costs and attorneys' fees, that arise from use of this data.
+---
+

--- a/_licenses/other.md
+++ b/_licenses/other.md
@@ -1,0 +1,7 @@
+---
+title: Other License
+layout: license
+permalink: /licenses/other
+body: The organization providing the database and data contained therein, and the end user’s use of the data does not constitute a transfer of, nor does the end user receive, any title or interest in the database or any other of the organization's data. The organization makes no representation about the accuracy of any specific information in this data and is provided “as is” and without Warranty of any kind. The user of this data will assume complete responsibility for any and all occurrences resulting from its use or display and will hold the organization harmless from any and all claims, demands, liabilities, obligations, damages, suits, judgments or settlements, including reasonable costs and attorneys' fees, that arise from use of this data.
+---
+

--- a/data.json
+++ b/data.json
@@ -6,6 +6,7 @@
     {% assign schema = dataset.schema | default: site.schema %}
     {% assign dataset_fields = site.data.schemas[schema].dataset_fields %}
     {% assign resource_fields = site.data.schemas[schema].resource_fields %}
+    {% assign licenses = site.data.licenses %}
 
     {% assign f_title = dataset_fields | where: "datajson", "title" | first %}
     {% assign title = dataset[f_title[field_name]] %}
@@ -16,7 +17,9 @@
     {% assign publisher_name = dataset[f_publisherName[field_name]] %}
 
     {% assign f_license = dataset_fields | where: "datajson", "license" | first %}
-    {% assign license = dataset[f_license[field_name]] %}
+    {% assign license_name = dataset[f_license[field_name]] %}
+    {% assign license_model = licenses.items | find: "name", license_name %}
+    {% assign license_url = license_model.url %}
 
     {% assign f_description = dataset_fields | where: "datajson", "description" | first %}
     {% assign description = dataset[f_description[field_name]] %}
@@ -46,9 +49,8 @@
       "contactPoint": {
         "fn": {{ contact_point_fn | jsonify }}{% if contact_point_has_email %},
         "hasEmail": {{ contact_point_has_email | jsonify }}{% endif %}
-      }{% endif %}{% if license != '' %},
-      "license": "{{ license }}"
-      {% endif %}{% if dataset.resources %},
+      }{% endif %}{% if license_url != '' %},
+      "license": "{{ license_url }}"{% endif %}{% if dataset.resources %},
       "distribution": [{% for distribution in dataset.resources %}{% capture temp %}
         {% assign dist_title = distribution[f_dist_title[field_name]] %}
         {% assign dist_download_url = distribution[f_dist_download_url[field_name]] %}


### PR DESCRIPTION
related to issue #89

The license element of the DCAT standard calls for a URL with the license, rather than "Other (City of Philadelphia)" that we imported from CKAN. I'm not if this will suffice, but I don't think it will harm the web site to have it.