### PR TITLE
Update indego-bike-share-stations.md

### DIFF
--- a/_datasets/indego-bike-share-stations.md
+++ b/_datasets/indego-bike-share-stations.md
@@ -5,7 +5,6 @@ category:
 - Health / Human Services
 - Parks / Recreation
 - Transportation
-created: '2015-04-22T14:43:42.484908'
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
@@ -18,17 +17,17 @@ opendataphilly_rating: null
 organization: City of Philadelphia
 resources:
 - description: ''
-  format: API
-  name: Indego Bikeshare Station (API)
-  url: https://api.phila.gov/bike-share-stations/v1
+  format: HTML
+  name: Indego Bikeshare Stations
+  url: https://www.rideindego.com/about/data/
 - description: ''
   format: HTML
-  name: Indego Bikeshare Station (Metadata)
+  name: Indego Bikeshare Stations (Metadata)
   url: http://metadata.phila.gov/#home/datasetdetails/555a509d0ae7565761d9578c/representationdetails/5592d91f57efad1c29b97937/
 schema: philadelphia
 source: ''
 tags:
-- Mayors Office of Transportation and Utilities
+- Office of Transportation and Infrastructure System
 time_period: null
 title: Indego Bike Share Stations
 usage: null


### PR DESCRIPTION
The City owns the Indego bikeshare program, but Indego as a vendor shares the data out themselves. Updated the links because previous ones broke