### PR TITLE
Added alt attribute for GitHub image

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
       <img src="{{ site.logo }}" srcset="/img/odp-logo@2x.png 2x" alt="OpenDataPhilly" title="OpenDataPhilly">
     </a>
     <a class="github-logo d-md-none" href="https://github.com/opendataphilly/opendataphilly-jkan">
-      <img src="{{site.baseurl}}/img/github-mark-white.svg" width="30" height="30">
+      <img src="{{site.baseurl}}/img/github-mark-white.svg" alt="GitHub logo" width="30" height="30">
     </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -23,7 +23,7 @@
       </ul>
     </div>
     <a class="github-logo d-none d-md-block" href="https://github.com/opendataphilly/opendataphilly-jkan">
-      <img src="{{site.baseurl}}/img/github-mark-white.svg" width="30" height="30">
+      <img src="{{site.baseurl}}/img/github-mark-white.svg" alt="GitHub logo" width="30" height="30">
     </a>
   </div>
 </nav>


### PR DESCRIPTION
The PR Fixes #359. Adds the _alt_ attribute to the two GitHub imgs with the text "GitHub logo."