### PR TITLE
Fix bullet formatting on covid dataset

### DIFF
--- a/_datasets/covid-19-test-sites.md
+++ b/_datasets/covid-19-test-sites.md
@@ -14,9 +14,13 @@ notes: "A dataset of COVID-19 testing sites. A dataset of COVID-19 testing sites
   You will be asked for identification and will also be asked for health insurance information.
   Identification will be required to receive a test. If you don’t have health insurance,
   you may still be able to receive a test by paying out-of-pocket. Some sites may also:
+
    - Limit testing to people who meet certain criteria.
+
    - Require an appointment.
+
    - Require a referral from your doctor.
+
 
   Check a location’s specific details on the map. Then, call or visit the provider’s website before going for a test."
 opendataphilly_rating: null


### PR DESCRIPTION
@Kistine apologies for being slow to get to this question from [your PR](https://github.com/opendataphilly/opendataphilly-jkan/pull/384) last week!

here's a quick formatting fix and explanation:

the markdown required an extra newline between each bulleted line and two newlines following the last bullet. we may be able to get this working more intuitively at some point, but for now i thought it would be most expedient to toss a few extra newlines in, and it worked :)

please let me know if you have any other questions or issues!

![image](https://github.com/user-attachments/assets/678d8dd3-d70d-42cc-abb0-398461f90e02)
