### PR TITLE
adding url_encode for CARTO queries that have un-escaped characters.

### DIFF
--- a/_datasets/soil-survey-philadelphia-county.md
+++ b/_datasets/soil-survey-philadelphia-county.md
@@ -2,7 +2,7 @@
 area_of_interest: Philadelphia County (City of Philadelphia)
 category:
 - Environment
-created: '2022'
+created: '2024'
 license: License Not Specified
 maintainer: U.S. Department of Agriculture, Natural Resources Conservation Service, National Soil Survey Center
 maintainer_email: SoilsHotline@usda.gov
@@ -26,15 +26,15 @@ resources:
 - description: ''
   format: XML
   name: Philadelphia County Soils XML Metadata
-  url: http://www.pasda.psu.edu/uci/FullMetadataDisplay.aspx?file=PA_Soils2022.xml
+  url: https://www.pasda.psu.edu/uci/FullMetadataDisplay.aspx?file=wss_SSA_PA101_soildb_Philadelphia_PA_2003_%5B2024-09-04%5D.xml
 - description: ''
   format: SHP
   name: Philadelphia County Soils Shapefile
-  url: https://www.pasda.psu.edu/download/soils/wss_SSA_PA101_soildb_Philadelphia_PA_2003_[2022-09-06].zip
+  url: https://www.pasda.psu.edu/download/soils/wss_SSA_PA101_soildb_Philadelphia_PA_2003_%5B2024-09-04%5D.zip
 - description: ''
   format: GeoJSON
   name: Philadelphia County Soils GeoJSON
-  url: https://www.pasda.psu.edu/json/PA_Soils2022.geojson
+  url: https://www.pasda.psu.edu/json/PA_Soils2024.geojson
 - description: ''
   format: API
   name: Philadelphia County Soils ArcGIS REST API

--- a/data.json
+++ b/data.json
@@ -176,11 +176,55 @@
             {% assign access_flag = true -%}
          {%- endif -%}
 
+         {%- if dist_download_url contains "|asc" or dist_download_url contains "|desc" -%}
+            {%- assign dist_download_url = dist_download_url | replace: "|", "%7C" -%}
+         {%- endif -%}
+         
          {%- if dist_download_url contains "phl.carto.com" -%}
-           {%- assign url_parts = dist_download_url | split: "q=" -%}
-           {%- if url_parts.size > 1 and url_parts[1] contains "SELECT * " -%}
-             {%- assign encoded_query = url_parts[1] | url_encode -%}
-             {%- assign dist_download_url = url_parts[0] | append: "q=" | append: encoded_query -%}
+           {%- assign url_parts = dist_download_url | split: "?" -%}
+           {%- if url_parts.size > 1 -%}
+             {%- assign query_string = url_parts[1] -%}
+             {%- assign query_params = query_string | split: "&" -%}
+             {%- assign encoded_params = "" -%}
+             {%- for param in query_params -%}
+               {%- assign param_parts = param | split: "=" -%}
+               {%- if param_parts.size > 1 -%}
+                 {%- assign param_name = param_parts[0] -%}
+                 {%- assign param_value = param_parts[1] -%}
+                 {%- if param_parts.size > 2 -%}
+                   {%- for i in (2..param_parts.size) -%}
+                     {%- if forloop.first -%}
+                       {%- assign param_value = param_value | append: "=" | append: param_parts[i] -%}
+                     {%- else -%}
+                       {%- assign param_value = param_value | append: param_parts[i] -%}
+                     {%- endif -%}
+                   {%- endfor -%}
+                 {%- endif -%}
+                 {%- if param_name == "q" -%}
+                   {%- assign is_encoded = false -%}
+                   {%- if param_value contains "%" or param_value contains "+" -%}
+                     {%- assign decoded_value = param_value | url_decode -%}
+                     {%- if decoded_value != param_value -%}
+                       {%- assign is_encoded = true -%}
+                     {%- endif -%}
+                   {%- endif -%}
+                   {%- unless is_encoded -%}
+                     {%- assign encoded_value = param_value | url_encode -%}
+                   {%- else -%}
+                     {%- assign encoded_value = param_value -%}
+                   {%- endunless -%}
+                 {%- else -%}
+                   {%- assign encoded_value = param_value -%}
+                 {%- endif -%}
+                 {%- assign encoded_param = param_name | append: "=" | append: encoded_value -%}
+                 {%- if forloop.first -%}
+                   {%- assign encoded_params = encoded_param -%}
+                 {%- else -%}
+                   {%- assign encoded_params = encoded_params | append: "&" | append: encoded_param -%}
+                 {%- endif -%}
+               {%- endif -%}
+             {%- endfor -%}
+             {%- assign dist_download_url = url_parts[0] | append: "?" | append: encoded_params -%}
            {%- endif -%}
          {%- endif -%}
 

--- a/data.json
+++ b/data.json
@@ -176,6 +176,14 @@
             {% assign access_flag = true -%}
          {%- endif -%}
 
+         {%- if dist_download_url contains "phl.carto.com" -%}
+           {%- assign url_parts = dist_download_url | split: "q=" -%}
+           {%- if url_parts.size > 1 and url_parts[1] contains "SELECT * " -%}
+             {%- assign encoded_query = url_parts[1] | url_encode -%}
+             {%- assign dist_download_url = url_parts[0] | append: "q=" | append: encoded_query -%}
+           {%- endif -%}
+         {%- endif -%}
+
          {
             "title": {{ dist_title | jsonify }},
             {%- if access_flag %}


### PR DESCRIPTION
trying to resolve resource URL errors being generated by DCAT validator 

#89 