### PR TITLE
Fix typos to eliminate redundant dataset categories

### DIFF
--- a/_datasets/city-owned-properties.md
+++ b/_datasets/city-owned-properties.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category: 
 - Real Estate / Land Records
-- Plannning / Zoning
+- Planning / Zoning
 created: '2015-01-30T19:40:59.857775'
 license: City of Philadelphia License
 maintainer: PHDC

--- a/_datasets/dvrpcs-equity-through-access-map-toolkit.md
+++ b/_datasets/dvrpcs-equity-through-access-map-toolkit.md
@@ -3,7 +3,7 @@ area_of_interest: "\tDelaware Valley (Camden; Gloucester; Mercer; Bucks; Chester
   \ Delaware; Montgomery; Philadelphia counties)"
 category: 
 - Parks / Recreation
-- Health / Humans Services
+- Health / Human Services
 - Transportation
 created: '2017-06-27T15:13:17.062929'
 license: License Not Specified

--- a/_datasets/fatal-crashes.md
+++ b/_datasets/fatal-crashes.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Transporation
+- Transportation
 - Health / Human Services
 license: City of Philadelphia License
 maintainer: Captain Heinzeroth

--- a/_datasets/licenses-and-inspections-case-investigations.md
+++ b/_datasets/licenses-and-inspections-case-investigations.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 - Real Estate / Land Records
 created: '2016-09-22T16:17:08.376879'
 license: City of Philadelphia License

--- a/_datasets/licenses-and-inspections-clean-and-seal.md
+++ b/_datasets/licenses-and-inspections-clean-and-seal.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 - Real Estate / Land Records
 created: '2016-09-22T18:07:28.682465'
 license: City of Philadelphia License

--- a/_datasets/licenses-and-inspections-complaints.md
+++ b/_datasets/licenses-and-inspections-complaints.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 - Real Estate / Land Records
 - Environment
 created: '2016-09-22T14:31:12.542396'

--- a/_datasets/licenses-and-inspections-district-offices.md
+++ b/_datasets/licenses-and-inspections-district-offices.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 - Real Estate / Land Records
 created: '2019-08-06T13:29:46.242146'
 license: City of Philadelphia License

--- a/_datasets/licenses-and-inspections-trade-licenses.md
+++ b/_datasets/licenses-and-inspections-trade-licenses.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 - Real Estate / Land Records
 created: '2016-09-22T21:15:57.272811'
 license: City of Philadelphia License

--- a/_datasets/outdoor-advertising.md
+++ b/_datasets/outdoor-advertising.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 - Environment
 created: '2016-04-25T22:09:17.756565'
 license: City of Philadelphia License

--- a/_datasets/pa-dot-transportation-improvement-projects.md
+++ b/_datasets/pa-dot-transportation-improvement-projects.md
@@ -14,42 +14,42 @@ organization: PA Department of Transportation
 resources:
 - description: ''
   format: SHP
-  name: PA Transporation Improvement Projects Lines Shapefile
+  name: PA Transportation Improvement Projects Lines Shapefile
   url: https://www.pasda.psu.edu/download/padot/state/PA_TransportationImprovementProjects_Line2024_03.zip
 - description: ''
   format: GeoJSON
-  name: PA Transporation Improvement Projects Lines GeoJSON
+  name: PA Transportation Improvement Projects Lines GeoJSON
   url: https://www.pasda.psu.edu/json/PA_TransportationImprovementProjects_Line2024_03.geojson
 - description: ''
   format: API
-  name: PA Transporation Improvement Projects Lines REST API
+  name: PA Transportation Improvement Projects Lines REST API
   url: https://mapservices.pasda.psu.edu/server/rest/services/pasda/PennDOT/MapServer
 - description: ''
   format: HTML
-  name: PA Transporation Improvement Projects Lines Metadata
+  name: PA Transportation Improvement Projects Lines Metadata
   url: https://www.pasda.psu.edu/uci/FullMetadataDisplay.aspx?file=PA_TransportationImprovementProjects_Line2024_03.xml
 - description: ''
   format: SHP
-  name: PA Transporation Improvement Projects Points Shapefile
+  name: PA Transportation Improvement Projects Points Shapefile
   url: https://www.pasda.psu.edu/download/padot/state/PA_TransportationImprovementProjects_Point2024_03.zip
 - description: ''
   format: GeoJSON
-  name: PA Transporation Improvement Projects Points GeoJSON
+  name: PA Transportation Improvement Projects Points GeoJSON
   url: https://www.pasda.psu.edu/json/PA_TransportationImprovementProjects_Point2024_03.geojson
 - description: ''
   format: API
-  name: PA Transporation Improvement Projects Points REST API
+  name: PA Transportation Improvement Projects Points REST API
   url: https://mapservices.pasda.psu.edu/server/rest/services/pasda/PennDOT/MapServer
 - description: ''
   format: HTML
-  name: PA Transporation Improvement Projects Points Metadata
+  name: PA Transportation Improvement Projects Points Metadata
   url: https://www.pasda.psu.edu/uci/FullMetadataDisplay.aspx?file=PA_TransportationImprovementProjects_Point2024_03.xml
 schema: philadelphia
 source: null
 tags: 
 - infrastructure
 time_period: March 2024
-title: PA Transporation Improvement Projects
+title: PA Transportation Improvement Projects
 usage: Public Use; Free
 ---
 

--- a/_datasets/parking-meter-kiosk-inventory.md
+++ b/_datasets/parking-meter-kiosk-inventory.md
@@ -1,7 +1,7 @@
 ---
 area_of_interest: null
 category: 
-- Planning / Zonng
+- Planning / Zoning
 created: '2015-01-21T14:17:47.544851'
 license: City of Philadelphia License
 maintainer: ''

--- a/_datasets/pwd-stormwater-billing-parcels.md
+++ b/_datasets/pwd-stormwater-billing-parcels.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Environment
-- Real Estate/Land 
+- Real Estate / Land Records 
 license: City of Philadelphia License
 maintainer: null
 maintainer_email: null

--- a/_datasets/vacant-property-indicators-percentage-by-block.md
+++ b/_datasets/vacant-property-indicators-percentage-by-block.md
@@ -2,7 +2,7 @@
 area_of_interest: null
 category:
 - Planning / Zoning
-- Reeal Estate / Land Records
+- Real Estate / Land Records
 created: '2017-03-08T17:08:45.582983'
 license: City of Philadelphia License
 maintainer: maps@phila.gov 


### PR DESCRIPTION
On the left sidebar of [this page](https://opendataphilly.org/datasets/?category=health-human-services) (under "Categories"), there are a number of typos in the category names that result in redundant categories.

This pull request fixes these typos to eliminate the redundant categories and ensure the datasets are categorized properly.

![image](https://github.com/user-attachments/assets/ddcb4ea7-ae55-4749-8533-0a62bf6c8bc1)
