### PR TITLE
Update major-watersheds-philadelphia.md

### DIFF
--- a/_datasets/major-watersheds-philadelphia.md
+++ b/_datasets/major-watersheds-philadelphia.md
@@ -41,6 +41,7 @@ schema: philadelphia
 source: ''
 tags:
 - Philadelphia Water Department
+- watersheds
 time_period: null
 title: Major Watersheds - Philadelphia
 usage: Public Use; Free


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog