### PR TITLE
Update historic-streets.md

### DIFF
--- a/_datasets/historic-streets.md
+++ b/_datasets/historic-streets.md
@@ -3,7 +3,6 @@ area_of_interest: null
 category:
 - Planning / Zoning
 - Transportation
-created: '2015-06-09T07:17:26.585413'
 license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
@@ -16,15 +15,15 @@ resources:
 - description: ''
   format: CSV
   name: Historic Streets - Line (CSV)
-  url: https://opendata.arcgis.com/datasets/9409bce14c4e4768a11a8432e80bfa68_0.csv
+  url: https://hub.arcgis.com/api/v3/datasets/9409bce14c4e4768a11a8432e80bfa68_0/downloads/data?format=csv&spatialRefId=2272&where=1%3D1
 - description: ''
   format: SHP
   name: Historic Streets - Line (SHP)
-  url: https://opendata.arcgis.com/datasets/9409bce14c4e4768a11a8432e80bfa68_0.zip
+  url: https://hub.arcgis.com/api/v3/datasets/9409bce14c4e4768a11a8432e80bfa68_0/downloads/data?format=shp&spatialRefId=2272&where=1%3D1
 - description: ''
   format: GeoJSON
   name: Historic Streets - Line (GeoJSON)
-  url: https://opendata.arcgis.com/datasets/9409bce14c4e4768a11a8432e80bfa68_0.geojson
+  url: https://hub.arcgis.com/api/v3/datasets/9409bce14c4e4768a11a8432e80bfa68_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: ''
   format: API
   name: Historic Streets - Line (API)
@@ -36,15 +35,15 @@ resources:
 - description: ''
   format: CSV
   name: Historic Streets - Polygon (CSV)
-  url: https://opendata.arcgis.com/datasets/b2c418f6e531486283f0c35a1104faee_0.csv
+  url: https://hub.arcgis.com/api/v3/datasets/b2c418f6e531486283f0c35a1104faee_0/downloads/data?format=csv&spatialRefId=2272&where=1%3D1
 - description: ''
   format: SHP
   name: Historic Streets - Polygon (SHP)
-  url: https://opendata.arcgis.com/datasets/b2c418f6e531486283f0c35a1104faee_0.zip
+  url: https://hub.arcgis.com/api/v3/datasets/b2c418f6e531486283f0c35a1104faee_0/downloads/data?format=shp&spatialRefId=2272&where=1%3D1
 - description: ''
   format: GeoJSON
   name: Historic Streets - Polygon (GeoJSON)
-  url: https://opendata.arcgis.com/datasets/b2c418f6e531486283f0c35a1104faee_0.geojson
+  url: https://hub.arcgis.com/api/v3/datasets/b2c418f6e531486283f0c35a1104faee_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: ''
   format: API
   name: Historic Streets - Polygon (API)


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog