### PR TITLE
Update historic-streams.md

### DIFF
--- a/_datasets/historic-streams.md
+++ b/_datasets/historic-streams.md
@@ -2,7 +2,6 @@
 area_of_interest: null
 category:
 - Environment
-created: '2016-02-17T19:46:30.866683'
 license: City of Philadelphia License
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
@@ -16,15 +15,15 @@ resources:
 - description: ''
   format: CSV
   name: Historic Streams - Line (CSV)
-  url: https://opendata.arcgis.com/datasets/40816e75554f4d74991aaeca81b5bd26_0.csv
+  url: https://hub.arcgis.com/api/v3/datasets/40816e75554f4d74991aaeca81b5bd26_0/downloads/data?format=csv&spatialRefId=2272&where=1%3D1
 - description: ''
   format: SHP
   name: Historic Streams - Line (SHP)
-  url: https://opendata.arcgis.com/datasets/40816e75554f4d74991aaeca81b5bd26_0.zip
+  url: https://hub.arcgis.com/api/v3/datasets/75caa1d4e8724a33b0eaac967271a9d4_0/downloads/data?format=shp&spatialRefId=2272&where=1%3D1
 - description: ''
   format: GeoJSON
   name: Historic Streams - Line (GeoJSON)
-  url: https://opendata.arcgis.com/datasets/40816e75554f4d74991aaeca81b5bd26_0.geojson
+  url: https://hub.arcgis.com/api/v3/datasets/40816e75554f4d74991aaeca81b5bd26_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: ''
   format: API
   name: Historic Streams - Line (API)
@@ -36,15 +35,15 @@ resources:
 - description: ''
   format: CSV
   name: Historic Streams - Polygon (CSV)
-  url: https://opendata.arcgis.com/datasets/75caa1d4e8724a33b0eaac967271a9d4_0.csv
+  url: https://hub.arcgis.com/api/v3/datasets/75caa1d4e8724a33b0eaac967271a9d4_0/downloads/data?format=csv&spatialRefId=2272&where=1%3D1
 - description: ''
   format: SHP
   name: Historic Streams - Polygon (SHP)
-  url: https://opendata.arcgis.com/datasets/75caa1d4e8724a33b0eaac967271a9d4_0.zip
+  url: https://hub.arcgis.com/api/v3/datasets/75caa1d4e8724a33b0eaac967271a9d4_0/downloads/data?format=shp&spatialRefId=2272&where=1%3D1
 - description: ''
   format: GeoJSON
   name: Historic Streams - Polygon (GeoJSON)
-  url: https://opendata.arcgis.com/datasets/75caa1d4e8724a33b0eaac967271a9d4_0.geojson
+  url: https://hub.arcgis.com/api/v3/datasets/75caa1d4e8724a33b0eaac967271a9d4_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: ''
   format: API
   name: 'Historic Streams - Polygon (API) '


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog