### PR TITLE
Update track-streets.md

### DIFF
--- a/_datasets/track-streets.md
+++ b/_datasets/track-streets.md
@@ -3,7 +3,6 @@ area_of_interest: null
 category:
 - Planning / Zoning
 - Transportation
-created: '2015-09-21T16:37:09.733341'
 license: City of Philadelphia License
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
@@ -16,15 +15,15 @@ resources:
 - description: ''
   format: CSV
   name: Track Streets (CSV)
-  url: https://opendata.arcgis.com/api/v3/datasets/474e6d9781a44135afa805fa985bc4ef_0/downloads/data?format=csv&spatialRefId=4326
+  url: https://hub.arcgis.com/api/v3/datasets/474e6d9781a44135afa805fa985bc4ef_0/downloads/data?format=csv&spatialRefId=2272&where=1%3D1
 - description: ''
   format: SHP
   name: Track Streets (SHP)
-  url: https://opendata.arcgis.com/api/v3/datasets/474e6d9781a44135afa805fa985bc4ef_0/downloads/data?format=shp&spatialRefId=4326
+  url: https://hub.arcgis.com/api/v3/datasets/474e6d9781a44135afa805fa985bc4ef_0/downloads/data?format=shp&spatialRefId=2272&where=1%3D1
 - description: ''
   format: GeoJSON
   name: Track Streets (GeoJSON)
-  url: https://opendata.arcgis.com/datasets/474e6d9781a44135afa805fa985bc4ef_0.geojson
+  url: https://hub.arcgis.com/api/v3/datasets/474e6d9781a44135afa805fa985bc4ef_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: ''
   format: API
   name: Track Streets (API)


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog