### PR TITLE
Update tobacco-retailer-density-caps.md

### DIFF
--- a/_datasets/tobacco-retailer-density-caps.md
+++ b/_datasets/tobacco-retailer-density-caps.md
@@ -21,15 +21,15 @@ resources:
 - description: ''
   format: CSV
   name: Tobacco Retailer Density Caps (CSV)
-  url: https://opendata.arcgis.com/api/v3/datasets/dd85d1bf45cd43d5a02b9b58eed01c02_0/downloads/data?format=csv&spatialRefId=4326&where=1%3D1
+  url: https://hub.arcgis.com/api/v3/datasets/dd85d1bf45cd43d5a02b9b58eed01c02_0/downloads/data?format=csv&spatialRefId=3857&where=1%3D1
 - description: ''
   format: SHP
   name: Tobacco Retailer Density Caps (SHP)
-  url: https://opendata.arcgis.com/api/v3/datasets/dd85d1bf45cd43d5a02b9b58eed01c02_0/downloads/data?format=shp&spatialRefId=4326&where=1%3D1
+  url: https://hub.arcgis.com/api/v3/datasets/dd85d1bf45cd43d5a02b9b58eed01c02_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1
 - description: ''
   format: GeoJSON
   name: Tobacco Retailer Density Caps (GeoJSON)
-  url: https://opendata.arcgis.com/api/v3/datasets/dd85d1bf45cd43d5a02b9b58eed01c02_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
+  url: https://hub.arcgis.com/api/v3/datasets/dd85d1bf45cd43d5a02b9b58eed01c02_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: ''
   format: API
   name: Tobacco Retailer Density Caps (API)


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog