### PR TITLE
Replaced 'opendataphilly-rating' with 'modified' in the schema (we ha…

### DIFF
--- a/_data/schemas/philadelphia.yml
+++ b/_data/schemas/philadelphia.yml
@@ -31,8 +31,10 @@ dataset_fields:
     label: Maintainer Link
   - field_name: maintainer_phone
     label: Maintainer Phone
-  - field_name: opendataphilly_rating
-    label: OpenDataPhilly Rating
+  - field_name: modified
+    label: Last Updated
+    datajson: modified
+    display_template: display/date.html
   - field_name: source
     label: Source
   - field_name: time_period

--- a/_datasets/2009-2012-police-advisory-commission-complaints.md
+++ b/_datasets/2009-2012-police-advisory-commission-complaints.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "The datasets below show information about Complaints filed with the Police\
   \ Advisory Commission against Philadelphia Police officers. The information comes\
   \ directly from Police Advisory Commission Complaint Database."
-opendataphilly_rating: '6'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Never'

--- a/_datasets/311-service-and-information-requests.md
+++ b/_datasets/311-service-and-information-requests.md
@@ -19,7 +19,7 @@ notes: "This represents all service and information requests since December 8th,
   \ links to access this data. You can learn more about how to use the API at [Carto\u2019\
   s SQL API site](https://carto.com/developers/sql-api/)  and in the [CARTO guide\
   \ in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/PBLN-program-grants.md
+++ b/_datasets/PBLN-program-grants.md
@@ -12,7 +12,7 @@ notes: "Philadelphia Business Lending Network (PBLN) Incentive Grant Program is 
   owners to get a loan for business startup, growth, or purchase of commercial property. This program builds on the innovative 
   Philadelphia Business Lending Network to provide additional funds in the form of grants, up to $35,000, up to 50% of loan amount, 
   to qualifying low-to-moderate income small businesses who obtain loans through the members of Philadelphia Business Lending Network."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/PHL-made-grant-program.md
+++ b/_datasets/PHL-made-grant-program.md
@@ -13,7 +13,7 @@ notes: "The purpose of this grant program is to support and encourage the growth
   manufacturing companies in the city. For the purpose of this grant program, the manufacturing industry is
   defined as companies engaged in the production of goods through the use of tools, labor, and machinery.
   This includes but is not limited to companies producing consumer goods, industrial goods, and medical devices."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/TMF-emergency-grants.md
+++ b/_datasets/TMF-emergency-grants.md
@@ -12,7 +12,7 @@ notes: "This dataset reflects the businesses that received emergency grant fundi
   Program. The program is administered by The Merchants Fund and funded by the Philadelphia Department of Commerce to support 
   businesses experiencing unexpected emergencies. Grants are designed to help small businesses recover from emergencies, 
   stabilize their operations, and continue serving their communities."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/active-residential-parking-permits-by-district.md
+++ b/_datasets/active-residential-parking-permits-by-district.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
   Discussion Group](http://www.phila.gov/data/discuss/)
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/advancing-education-safely.md
+++ b/_datasets/advancing-education-safely.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: The Advancing Education Safely dashboard includes information about COVID-19
   testing and confirmed cases for SDP students and staff in 2021-22.
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: 2020-2021

--- a/_datasets/aerial-photography.md
+++ b/_datasets/aerial-photography.md
@@ -10,7 +10,7 @@ maintainer_email: brian.ivey@phila.gov
 maintainer_link: null
 maintainer_phone: 215-686-8287
 notes: "Data includes aerial photography of the City of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/affordable-housing-production.md
+++ b/_datasets/affordable-housing-production.md
@@ -10,7 +10,7 @@ maintainer_email: null
 maintainer_link: null
 maintainer_phone: null
 notes: 'The Division of Housing and Community Development (DHCD) provides funding to developers to build and maintain affordable housing units throughout the city. This dataset includes all DHCD-funded housing projects completed since 1994 for which there is data.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/air-monitoring-stations.md
+++ b/_datasets/air-monitoring-stations.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Street location and types of pollutants sampled at each PDPH air monitoring\
   \ station."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "Update frequency: Yearly\r\n"

--- a/_datasets/air-quality-index-days.md
+++ b/_datasets/air-quality-index-days.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Number of bad AQI (air quality index) days, dating back to 1990."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ams-latest-air-quality-sensor-readings.md
+++ b/_datasets/ams-latest-air-quality-sensor-readings.md
@@ -16,7 +16,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "The latest air quality sensor readings managed by the Air Management Systems\
   \ (AMS) division of the Philadelphia Department of Public Health (PDPH)"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/archived-2007-2015-litter-index.md
+++ b/_datasets/archived-2007-2015-litter-index.md
@@ -17,7 +17,7 @@ notes: "The datasets below have been archived and will not receive further updat
   \ 2015 data is vastly different from the 2017 data, so it would not make sense to\
   \ compare the two. \r\n\r\nThe Litter Index is used to compare the relative cleanliness\
   \ of different areas of the city of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'This dataset is archived and will not receive further updates. '

--- a/_datasets/archived-greenworks-metrics.md
+++ b/_datasets/archived-greenworks-metrics.md
@@ -19,7 +19,7 @@ notes: "The following datasets are no longer maintained and will not receive fur
   \n*Have access to safe, affordable, and low-carbon transportation.\r\n*Waste less\
   \ and keep our neighborhoods clean.\r\n*Benefit from sustainability education, employment,\
   \ and business opportunities."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/archived-philadelphia-food-access.md
+++ b/_datasets/archived-philadelphia-food-access.md
@@ -18,7 +18,7 @@ notes: "The datasets below have been archived and will not receive further updat
   \ different from the more recent data, so it would not make sense to compare the\
   \ two.\r\n\r\nThis dataset is derived from the Walkable Access to Healthy Foods\
   \ in Philadelphia, 2012-2014 report analyses."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Archived'

--- a/_datasets/archived-valet-parking-locations.md
+++ b/_datasets/archived-valet-parking-locations.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Data is from 2015 and does not currently receive any updates. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/arterial-streets.md
+++ b/_datasets/arterial-streets.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "The Arterial layer was developed to aid various city agencies with planning,\
   \ organizing, and maintaining the streets of the City of Philadelphia.  These agencies\
   \ include PWD, PCPC, Police, BRT, Health, etc."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/big-belly-trash-bin-usage.md
+++ b/_datasets/big-belly-trash-bin-usage.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
   Discussion Group](http://www.phila.gov/data/discuss/)
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/big-belly-waste-baskets-trash-bins.md
+++ b/_datasets/big-belly-waste-baskets-trash-bins.md
@@ -8,7 +8,7 @@ maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Big Belly brand waste baskets maintained/collected by the City of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/bike-network-supporting-datasets.md
+++ b/_datasets/bike-network-supporting-datasets.md
@@ -15,7 +15,7 @@ notes: "This dataset combines data from various City of Philadelphia departments
    paths. Each dataset has its own parameters, dates, and sources, and individuals
    are encouraged to view the metadata associated with this data. 
    <i>This dataset is experimental and remains a work in progress. Please use with caution.</i>"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/bike-network.md
+++ b/_datasets/bike-network.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.phila.gov/streets/
 maintainer_phone: 215-686-5560
 notes: "Line data includes the network of both streets with bike lanes and streets\
   \ considered bicycle-friendly. Also known as the bicycle network. "
-opendataphilly_rating: '5'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/boost_business.md
+++ b/_datasets/boost_business.md
@@ -12,7 +12,7 @@ notes: 'The City of Philadelphia is launching Boost Your Business, a fund for eq
   Businesses owned by people of color face unique barriers in accessing resources and opportunities, which
   was only worsened by the COVID-19 pandemic. Boost Your Business will provide funding to help diverse
   entrepreneurs in Philadelphia scale their businesses.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/bridge-locations.md
+++ b/_datasets/bridge-locations.md
@@ -11,7 +11,7 @@ notes: "This layer was developed to aid the Bridge Division in maintaining and r
   \ the bridges of the City of Philadelphia.  Examples include: routing trucks with\
   \ height and weight restrictions through out the city, maintenance, and obtaining\
   \ bridge number."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/building-demolitions.md
+++ b/_datasets/building-demolitions.md
@@ -15,7 +15,7 @@ notes: "Inventory of building demolitions occurring within the City of Philadelp
   \ This includes both demolitions performed by private owners/contractors and by\
   \ the Department of Licenses and Inspections due to dangerous building conditions.\
   \ \r\n\r\nUpdated daily."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/building-footprints.md
+++ b/_datasets/building-footprints.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.phila.gov/dot/
 maintainer_phone: null
 notes: "Planimetric Coverage containing the delineation of buildings or related structure\
   \ outlines that represent the footprints of buildings within the City of Philadelphia."
-opendataphilly_rating: '4'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Weekly'

--- a/_datasets/bullet-voting-2015.md
+++ b/_datasets/bullet-voting-2015.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Each voter is allowed to select up to five candidates for City Council At-Large.\
   \ When a voter chooses only one candidate, it is known as 'bullet voting'."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: N/A'

--- a/_datasets/bus-shelters.md
+++ b/_datasets/bus-shelters.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This is a point dataset of bus transit shelters installed and maintained
   by the City of Philadelphia, in partnership with Intersection Media."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 

--- a/_datasets/business-improvement-districts.md
+++ b/_datasets/business-improvement-districts.md
@@ -14,7 +14,7 @@ as well the University City District and Sports Complex District. More informati
 This data set may be helpful to property owners, property purchasers or title companies seeking to know if a property exists within a BID. 
 Note that this dataset may include errors or outdated information. Therefore, it is strongly recommended that interested parties contact BID 
 organizations directly with inquiries.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/business-technical-support-resources.md
+++ b/_datasets/business-technical-support-resources.md
@@ -8,7 +8,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Services and support available to businesses in Philadelphia. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/buy-fresh-buy-local-pa.md
+++ b/_datasets/buy-fresh-buy-local-pa.md
@@ -18,7 +18,7 @@ notes: Buy Fresh, Buy Local is an online application that enables users to acces
   a map visualization. The application is maintained by the Pennsylvania Association
   for Sustainable Agriculture. Free registration enables commenting, blogging, uploading
   recipes and other interactive features.
-opendataphilly_rating: null
+modified: null
 organization: Pasa Sustainable Agriculture
 resources:
 - description: Map of locally produced food locations

--- a/_datasets/campaign-finance-reports.md
+++ b/_datasets/campaign-finance-reports.md
@@ -17,7 +17,7 @@ notes: "Campaign finance reports from 2019 to the present: The tables below show
   \ to understand how we compiled the data and dashboard. \r\n\r\nIf you want to use\
   \ the raw, unfiltered data, please visit the [searchable database](https://apps.phila.gov/search/all).\
   \ Filers can submit reports on via the [campaign finance filing system](https://apps.phila.gov/auth)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/candidates-for-elected-office.md
+++ b/_datasets/candidates-for-elected-office.md
@@ -9,7 +9,7 @@ maintainer_email: seth.bluestein@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Candidates for elected off from past elections since 2011 as well as candidates for the next election"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/census-block-groups.md
+++ b/_datasets/census-block-groups.md
@@ -18,7 +18,7 @@ notes: "For matching and analyzing demographic data collected and compiled by th
   \ U.S. Census Bureau & American Community Survey(ACS) to the geography of Census\
   \ Block Group boundaries within the City of Philadelphia. These boundaries can change\
   \ every ten years when the decennial census is conducted."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/census-blocks.md
+++ b/_datasets/census-blocks.md
@@ -19,7 +19,7 @@ notes: "The basic unit of aggregation published by the US Census Bureau.  Popula
   \ an urban area, this corresponds to approximately one city block.  This block map\
   \ has been altered to improve accuracy and align with the City of Philadelphia's\
   \ street centerline.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: For matching and analyzing demographic data collected and compiled

--- a/_datasets/census-tracts.md
+++ b/_datasets/census-tracts.md
@@ -19,7 +19,7 @@ notes: "For matching and analyzing demographic data collected and compiled by th
   \ Block Group boundaries within the City of Philadelphia. These boundaries can change\
   \ every ten years when the decennial census is conducted. Adjusted to City's Standard\
   \ Boundary Format.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: When the Census changes boundaries for each data

--- a/_datasets/center-city-district-boundary-business-improvement-district.md
+++ b/_datasets/center-city-district-boundary-business-improvement-district.md
@@ -13,7 +13,7 @@ notes: "Center City District encompasses 120 blocks and more than 4500 individua
   \ properties. The mission is to keep Center City clean, safe, and fun.  CCD also\
   \ makes phyiscal improvements to center city by installing and maintain lighting,\
   \ signs, banners trees and landscape.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/center-city-district-police-boundary.md
+++ b/_datasets/center-city-district-police-boundary.md
@@ -13,7 +13,7 @@ notes: "The Center City District (CCD) is a business improvement district. The m
   \ is to keep Center City clean, safe, and fun. CCD also makes phyiscal improvements\
   \ to center city by installing and maintain lighting, signs, banners trees and landscape.\
   \ This layer displays their policing boundary.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/certified-for-rental-suitability.md
+++ b/_datasets/certified-for-rental-suitability.md
@@ -11,7 +11,7 @@ maintainer_email: ligisteam@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Properties that have applied and been approved as suitable for renting. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/child-care-search.md
+++ b/_datasets/child-care-search.md
@@ -15,7 +15,7 @@ notes: Child Care Search is a searchable database, which yields results on child
   closely. In addition to location and contact information, qualitative information
   about care centers (STAR rating system ran) are also available. All information
   results are freely viewable and printable, but not exportable.
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Human Services
 resources:
 - description: ''

--- a/_datasets/childcare-map.md
+++ b/_datasets/childcare-map.md
@@ -23,7 +23,7 @@ notes: "Childcare Map helps Philadelphians make decisions about childcare.\r\n\r
   \ is important for the well-being of neighborhoods and families.  By identifying\
   \ areas where shortages of high-quality childcare exist, policymakers and investors\
   \ can work towards increasing access for all."
-opendataphilly_rating: null
+modified: null
 organization: Reinvestment Fund
 resources:
 - description: ''

--- a/_datasets/choice-neighborhoods.md
+++ b/_datasets/choice-neighborhoods.md
@@ -13,7 +13,7 @@ notes: "The Choice Neighborhoods program is administered by the U.S. Department 
   \ Housing and Urban Development (HUD).  It supports locally driven strategies to\
   \ address struggling neighborhoods with distressed public or HUD-assisted housing\
   \ through a comprehensive approach to neighborhood transformation. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/circuit-map.md
+++ b/_datasets/circuit-map.md
@@ -10,7 +10,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: Map of the existing and planning segments of the regional trail network
-opendataphilly_rating: null
+modified: null
 organization: Bicycle Coalition of Greater Philadelphia
 resources:
 - description: ''

--- a/_datasets/city-council-districts.md
+++ b/_datasets/city-council-districts.md
@@ -9,7 +9,7 @@ maintainer_email: darshna.patel@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "City Council Districts for a variety of different years."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed '

--- a/_datasets/city-employee-earnings.md
+++ b/_datasets/city-employee-earnings.md
@@ -20,7 +20,7 @@ notes: "__This data does not necessarily represent current salaries of employees
   \ the BASE_SALARY column is blank, it represents part-time, temporary, or seasonal\
   \ employees paid by the hour. Please see [metadata](https://metadata.phila.gov/#home/datasetdetails/5543865520583086178c4ebd/representationdetails/604284dc49a209001d746460/?view_287_per_page=25&view_287_page=1)\
   \ for detailed explanations of each field.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: A visualization of the latest  available quarter's data on City of

--- a/_datasets/city-facilities-master-facilities-database.md
+++ b/_datasets/city-facilities-master-facilities-database.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "An inventory of buildings and other fixed assets owned, leased, or operated\
   \ by the City of Philadelphia including buildings, structures, and properties (not\
   \ including surplus properties). Also known as the Master Facilities Database. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-landmarks.md
+++ b/_datasets/city-landmarks.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "An inventory of cultural landmarks found within the borders of the City of\
   \ Philadelphia. This data is used to populate the [City's basemap](https://opendataphilly.org/datasets/philadelphia-basemaps/)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "Give feedback on and submit missing landmarks of cultural, historical\

--- a/_datasets/city-limits.md
+++ b/_datasets/city-limits.md
@@ -11,7 +11,7 @@ maintainer_phone: 215-683-4600
 notes: "To provide a base for very generalized maps or used as an outline in conjunction\
   \ with other data layers.  Establishes City Limits for City's Standard Boundary\
   \ Format. This layer was updated on July 22, 2012.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-operating-budget.md
+++ b/_datasets/city-operating-budget.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.phila.gov/finance/contact.html
 maintainer_phone: null
 notes: "Proposed, adopted, and estimated operating budgets for City of Philadelphia\
   \ government. The City's Fiscal Year begins July 1st and ends June 30th."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/city-owned-bridges.md
+++ b/_datasets/city-owned-bridges.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This layer identifies the point locations of the city owned bridges that are\
   \ maintained by the Bridge Division of the City of Philadelphia Streets Department."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-owned-properties.md
+++ b/_datasets/city-owned-properties.md
@@ -14,7 +14,7 @@ notes: "The application below was a point-in-time analysis and has been archived
   If you're instead looking for an inventory of buildings and other fixed assets owned, leased, or operated by the
   City, please see the [City Facilities dataset]([https://www.opendataphilly.org/datasets/litter-index]
   (https://opendataphilly.org/datasets/city-facilities-master-facilities-database/)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: A map of all properties in 2015 in public ownership that are available. It

--- a/_datasets/city-payments.md
+++ b/_datasets/city-payments.md
@@ -29,7 +29,7 @@ notes: "This dataset includes checks and ACH (direct deposit) payments made by t
   \ and benefits data or payments the City makes to fund the operations of the First\
   \ Judicial District.\r\n- Vendors should use the [vendor payment website](https://secure.phila.gov/finance/vendorpayments/),\
   \ not this dataset, to track payments."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: A data visualization of the City of Philadelphia's FY2017 payments.

--- a/_datasets/city-plan-boundary.md
+++ b/_datasets/city-plan-boundary.md
@@ -12,7 +12,7 @@ notes: "This layer was developed to aid the Surveys Division in planning, modify
   \ and referencing the streets within a city plan of the City of Philadelphia.  Examples\
   \ include:  building new streets, modifying existing streets, or observing current\
   \ streets."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-registered-local-businesses.md
+++ b/_datasets/city-registered-local-businesses.md
@@ -13,7 +13,7 @@ notes: "The City of Philadelphia gives preference to certified local businesses 
   \ its Local Business Entity program. This dataset provides a list of currently certified\
   \ local businesses registered with the City of Philadelphia.\r\n\r\nFor more information,\
   \ visit:\r\nhttps://www.phila.gov/departments/procurement-department/local-preference/"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/civil-service-positions-details.md
+++ b/_datasets/civil-service-positions-details.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "These datasets show job classification and pay ranges details about Civil\
   \ Service positions approved by the Civil Service commission and Administrative\
   \ board."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/clean-plates-restaurant-health-inspections.md
+++ b/_datasets/clean-plates-restaurant-health-inspections.md
@@ -12,7 +12,7 @@ notes: 'The Inquirer has assembled restaurant food inspection data for four coun
   Philadelphia, Bucks Country, Gloucester County, Montgomery County. Violations include
   risk factors for foodborne illness and lack of good retail practices. Updated on
   an ongoing basis.'
-opendataphilly_rating: null
+modified: null
 organization: The Philadelphia Inquirer
 resources:
 - description: Searchable database of restaurant inspections in Philadelphia and surrounding

--- a/_datasets/combined-sewer-service-area.md
+++ b/_datasets/combined-sewer-service-area.md
@@ -15,7 +15,7 @@ notes: "This layer is dissolved and queried from PWD's internal sewer shed featu
   \ models. Data DevelopmentBase Modelsheds are maintained regularly and delineate\
   \ waste water and stormwater and combined sewer catchments in Philadelphia. Storm\
   \ water and waste water pipe flow are analyzed to delineate the shed boundaries."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/commercial-corridors-of-philadelphia.md
+++ b/_datasets/commercial-corridors-of-philadelphia.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "These are commercial corridors, centers, districts, and projects that provide\
   \ consumer-oriented goods and services, including retail, food and beverage, and\
   \ personal, professional, and business services. \r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/commodities-contracts.md
+++ b/_datasets/commodities-contracts.md
@@ -15,7 +15,7 @@ notes: "Commodities contracts are bid and awarded by the Procurement Department,
   \ a new tab, simple right click on the page, and choose 'save as.' When the save\
   \ as dialog box appears, make sure the 'save as type' is Microsoft Excel Comma Separated\
   \ Values File. You should then be able to open in excel.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'An app to view procurement contracts.  '

--- a/_datasets/community-compost-network-site.md
+++ b/_datasets/community-compost-network-site.md
@@ -10,7 +10,7 @@ maintainer_email: chris.park@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Community compost network sites located throughout the City of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -17,7 +17,7 @@ notes: "The Community Health Assessment (CHA) is a systematic assessment of popu
   \ 'Related' tab. Additionally, they have released an online, interactive version\
   \ of the CHA, known as the Community Health Explorer, to make the data more accessible\
   \ to a broader audience."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Interactive web application with charts and maps of the community

--- a/_datasets/community-services.md
+++ b/_datasets/community-services.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: A list of humanitarian resources within Philadelphia. Includes homeless shelters,
   health clinics, food pantries, soup kitchens, women and children shelters, etc.
-opendataphilly_rating: null
+modified: null
 organization: Code for Philly
 resources:
 - description: A list of homeless shelters, women and family shelters, health clinics,

--- a/_datasets/complaints-against-police.md
+++ b/_datasets/complaints-against-police.md
@@ -18,7 +18,7 @@ notes: "As part of the Philadelphia Police Department's (PPD) accountability pro
   History dataset details the timeline by which PPD released the complaint, concluded the
   investigation, and determined any resulting discipline. See metadata links below
   for dataset and field descriptions. Includes data from the past five years. Updated monthly."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Updated monthly. '

--- a/_datasets/complete-streets.md
+++ b/_datasets/complete-streets.md
@@ -15,7 +15,7 @@ notes: "The Complete Streets Layer combines the Street Types developed by the Ci
   \ developers, planners, engineers and community groups to easily identify their\
   \ street type and associated pedestrian, bicycle and other travel priorities to\
   \ be included during the planning of new streets or large developments."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/condom-distribution-sites.md
+++ b/_datasets/condom-distribution-sites.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Street location and hours of stores and organizations that distribute PDPH\
   \ Freedom Condom-branded condoms."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "Update frequency: Biannually\r\n\r\n"

--- a/_datasets/correctional-facilities-locations.md
+++ b/_datasets/correctional-facilities-locations.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "These layers illustrate 10 correctional facilities in the City, administered\
   \ by the Philadelphia Prisons System.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/courts.md
+++ b/_datasets/courts.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "Point data of all First Judicial District of PA courts. Aside from the courts\
   \ and locations, a main telephone number was added for each court. All information\
   \ was provided by http://www.courts.phila.gov/locations.asp\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/covid-19-test-sites.md
+++ b/_datasets/covid-19-test-sites.md
@@ -23,7 +23,7 @@ notes: "A dataset of COVID-19 testing sites. A dataset of COVID-19 testing sites
 
 
   Check a location’s specific details on the map. Then, call or visit the provider’s website before going for a test."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-19-vaccinations.md
+++ b/_datasets/covid-19-vaccinations.md
@@ -14,7 +14,7 @@ notes: "***As of May 2022, these datasets moved from daily updates to weekly upd
   \ well as total dose information for all vaccinations performed by the health department.\
   \ Also provides vaccinations by census tract, ZIP code, date, age, race, and sex.\
   \ Vaccinations include residents and non-residents of Philadelphia. Updates daily."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-cumulative-historical-snapshots.md
+++ b/_datasets/covid-cumulative-historical-snapshots.md
@@ -17,7 +17,7 @@ notes: The City of Philadelphia's datasets are snapshots published on a daily ba
   and death by race and hospitalizations are accumulated since 8/15/2020. Data is
   collected from the City's data published at https://www.opendataphilly.org/showcase/philadelphia-covid-19-information
   through a daily scrape of the web site.
-opendataphilly_rating: null
+modified: null
 organization: Ambient Point
 resources:
 - description: ''

--- a/_datasets/covid-deaths.md
+++ b/_datasets/covid-deaths.md
@@ -20,7 +20,7 @@ notes: "***As of May 2022, these datasets moved from daily updates to weekly upd
   \ or age. You can [find COVID cases datasets here](https://www.opendataphilly.org/datasets/covid-cases).\
   \ To protect the confidentiality of residents, PDPH suppresses the exact data for\
   \ any categories that have less than 6 counts (i.e. of cases or fatalities)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-hospitalizations.md
+++ b/_datasets/covid-hospitalizations.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "***As of May 2022, these datasets moved from daily updates to weekly updates\
   \ every Monday.***\r\n\r\nA break down by census categories of the hospitalizations\
   \ to date within the city limits."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-tests-and-cases.md
+++ b/_datasets/covid-tests-and-cases.md
@@ -21,7 +21,7 @@ notes: "***As of May 2022, these datasets moved from daily updates to weekly upd
   \ tests by date, zip, and outcome and cases by race, age or sex.  To protect the\
   \ confidentiality of residents, PDPH suppresses the exact data for any categories\
   \ that have less than 6 counts (i.e. of tests or fatalities).\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/crashes.md
+++ b/_datasets/crashes.md
@@ -12,7 +12,7 @@ notes: "This data set contains crash data for many years from the Pennsylvania\
   \ Department of Transportation (Penn DOT). This is a subset of the [annual Crash\
   \ Data compiled](https://crashinfo.penndot.gov/PCIT/welcome.html) and released by\
   \ Penn DOT for the entire state."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Vision Zero dashboard on reducing traffic deaths. 

--- a/_datasets/creal-program.md
+++ b/_datasets/creal-program.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Commercial Real Estate Acquisition Loan Program (CREAL) is a City of Philadelphia program administered through a CDFI, 
   currently the Women's Opportunities Resource Center (WORC). This program is designed to assist undercapitalized business owners 
   in securing loans to purchase commercial spaces for their operations."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/crime-incidents.md
+++ b/_datasets/crime-incidents.md
@@ -16,7 +16,7 @@ notes: "Crime incidents from the Philadelphia Police Department. Part I crimes i
   \ you can also use the API links to access this data. You can learn more about how\
   \ to use the API at Carto\u2019s SQL API site and in the Carto guide in the section\
   \ on making calls to the API.**"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: 'An online appication that displays summary statistics and enables mapping of recent incidents within a radius of an address.'

--- a/_datasets/crime-visualizations-in-philadelphia-county.md
+++ b/_datasets/crime-visualizations-in-philadelphia-county.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: The data on crime occurring in Philadelphia County is from the Philadelphia
   Police Department. The Philadelphia Inquirer has organized the data into a maps
   and charts. The data can be searched by year and neighborhood.
-opendataphilly_rating: null
+modified: null
 organization: The Philadelphia Inquirer
 resources:
 - description: Interactive map and charts of homicides 1988 - 2017

--- a/_datasets/curbs.md
+++ b/_datasets/curbs.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "This data includes curb edges with cartways and curb edges without cartways\
   \ to represent travelways within the City of Philadelphia and it aids in placement\
   \ of street centerline.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Quarterly '

--- a/_datasets/dams.md
+++ b/_datasets/dams.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This layer shows point representation of all the dams in Philadelphia with\
   \ latitude and longitude coordinates.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/delaware-river-basin-2070-land-cover-forecast.md
+++ b/_datasets/delaware-river-basin-2070-land-cover-forecast.md
@@ -20,7 +20,7 @@ notes: "DRB2070 Version 1.0 represents a baseline forecast of urban land cover i
   \n - https://drbproject.org/wp-content/uploads/sites/101/2017/03/DRB2070_v1.pdf\
   \ - March 2017\r\n - https://drbproject.org/wp-content/uploads/2017/07/DRB2070_v2.pdf\
   \ - July 2017\r\n"
-opendataphilly_rating: null
+modified: null
 organization: Shippensburg University of Pennsylvania
 resources:
 - description: The 2070 forecast is summarized as NHDPlus catchments (2001, 2011,

--- a/_datasets/delaware-river-basin-high-resolution-land-cover.md
+++ b/_datasets/delaware-river-basin-high-resolution-land-cover.md
@@ -21,7 +21,7 @@ notes: "High-resolution land cover dataset for the Delaware River Basin develope
   \ over Structures\r\n11 - Tree Canopy over Other Impervious Surfaces\r\n12 - Tree\
   \ Canopy over Roads\r\n\r\nUVM Spatial Analysis Lab request attribution in any publications,\
   \ reports, derivative datasets, etc."
-opendataphilly_rating: null
+modified: null
 organization: University of Vermont Spatial Analysis Lab
 resources:
 - description: One raster dataset for each county that intersects with Delaware River

--- a/_datasets/department-of-records-easement.md
+++ b/_datasets/department-of-records-easement.md
@@ -13,7 +13,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Polygon description of use rights for ingress/egress, driveways, alleyways,\
   \ utilities, drainage and subsurface areas."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/department-of-records-property-parcels.md
+++ b/_datasets/department-of-records-property-parcels.md
@@ -9,7 +9,7 @@ maintainer_link: http://www.phila.gov/records/
 maintainer_phone: null
 notes: "Department of Records (DOR) Boundaries of real estate property parcels derived\
   \ from legal recorded deed documents. \r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Weekly'

--- a/_datasets/digital-elevation-model-dem.md
+++ b/_datasets/digital-elevation-model-dem.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "A digital elevation model (DEM) is a 3D representation of\
   \ the Earth's surface, created from terrain elevation data. These DEMs were generated from LiDAR and LAS data was gathered for the City of Philadelphia"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/district-attorney-dashboard.md
+++ b/_datasets/district-attorney-dashboard.md
@@ -18,7 +18,7 @@ notes: "Interactive data reports on the Philadelphia District Attorney's Office'
   an interactive map displaying the data by police districts.
 
   The dashboard does not provide for downloading data. Data downloads can be found at https://opendataphilly.org/datasets/district-attorney/"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Use the data download tool to choose the topic of interest (i.e. arrests), the geography level (i.e. police district), and time frame to export as a csv or json dataset.'

--- a/_datasets/district-attorney.md
+++ b/_datasets/district-attorney.md
@@ -16,7 +16,7 @@ notes: "Summary data for each of several data sources can be downloaded
   summary charges. The data can be grouped by day, month, or year and filtered 
   based on a date range. It can also be downloaded as a city-wide dataset or 
   grouped by police district, zipcode, or census tract. The data is updated daily."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/district-employees-and-finance.md
+++ b/_datasets/district-employees-and-finance.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Expenditures, employee information, teacher attendance, teacher demographics,
   budgets, and full-time employees
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: 2015-2022 budget

--- a/_datasets/drink-philly-happy-hour-specials.md
+++ b/_datasets/drink-philly-happy-hour-specials.md
@@ -13,7 +13,7 @@ notes: 'Drink Philly provides listings of happy hours and drink and food special
   a list of featured specials sorted by day of the week and can be searched by neighborhood,
   type of special, type of bar, atmosphere, and drink prices. Profiles and reviews
   are available for many bars. '
-opendataphilly_rating: null
+modified: null
 organization: Drink Philly
 resources:
 - description: ''

--- a/_datasets/dvrpc-traffic-count-viewer.md
+++ b/_datasets/dvrpc-traffic-count-viewer.md
@@ -21,7 +21,7 @@ notes: 'Traffic Count Viewer is an online mapping application, which users can u
   are available for export in multiple formats (including basic .doc and .rtf outputs.)
   Traffic count data is collected by the Delaware Valley Regional Planning Commission
   and other agencies. '
-opendataphilly_rating: null
+modified: null
 organization: Delaware Valley Regional Planning Commission (DVRPC)
 resources:
 - description: ''

--- a/_datasets/dvrpcs-connections-2040-choices-voices.md
+++ b/_datasets/dvrpcs-connections-2040-choices-voices.md
@@ -19,7 +19,7 @@ notes: "Choices & Voices version 2.1 allows you to participate in developing a v
   \ 2040 Plan for Greater Philadelphia. This amendment reflects transportation increased\
   \ funding levels in Pennsylvania from the passage of Act 89 of 2013. \r\n\r\nChoices\
   \ & Voices was a winner of the U.S. DOT 2014 Data Innovation Challenge. "
-opendataphilly_rating: null
+modified: null
 organization: Delaware Valley Regional Planning Commission (DVRPC)
 resources:
 - description: "Choices & Voices version 2.1 allows you to participate in developing\

--- a/_datasets/dvrpcs-equity-through-access-map-toolkit.md
+++ b/_datasets/dvrpcs-equity-through-access-map-toolkit.md
@@ -20,7 +20,7 @@ notes: As part of the Equity Through Acesss project, DVRPC created the ETA Map T
   and areas where transit access is low. These three variables were combined to create
   the Priority Score map, which visualizes areas where new public transit connections
   could be made, changed, or improved to bridge access gaps in the future.
-opendataphilly_rating: null
+modified: null
 organization: Delaware Valley Regional Planning Commission (DVRPC)
 resources:
 - description: ''

--- a/_datasets/economic-opportunity-plans.md
+++ b/_datasets/economic-opportunity-plans.md
@@ -9,7 +9,7 @@ maintainer_email: nicholas.jann@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Economic Opportunity Plans (EOP)\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/elected-committee-people.md
+++ b/_datasets/elected-committee-people.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This data set is a list of elected Committee People by ward, division, and\
   \ party."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Visit this site to download excel files for Democratic and Republican

--- a/_datasets/election-board-who-worked-on-election-day.md
+++ b/_datasets/election-board-who-worked-on-election-day.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This data reflects which Election Board Officials worked on Election Day and\
   \ received payment for their services.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/election-results.md
+++ b/_datasets/election-results.md
@@ -8,7 +8,7 @@ maintainer_email: 'vote@phila.gov'
 maintainer_link: null
 maintainer_phone: null
 notes: "Certified election results for both primary and general elections.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description:

--- a/_datasets/empowerment-zones.md
+++ b/_datasets/empowerment-zones.md
@@ -14,7 +14,7 @@ notes: "Data includes commercial and industrial zones, i.e. areas with specific 
   \ businesses in blighted areas. Blighted areas are defined as meeting one of seven\
   \ city mandated criteria, including unsafe, unsanitary and inadequate conditions;\
   \ economically or socially undesirable land use; and faulty street and lot layout."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/enterprise-zones.md
+++ b/_datasets/enterprise-zones.md
@@ -16,7 +16,7 @@ notes: "Please note that the enterprise zones expired in the early 2000s, theref
   \ businesses in blighted areas. Blighted areas are defined as meeting one of seven\
   \ city mandated criteria, including unsafe, unsanitary and inadequate conditions;\
   \ economically or socially undesirable land use; and faulty street and lot layout."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/existing-trails.md
+++ b/_datasets/existing-trails.md
@@ -14,7 +14,7 @@ This feature class was used to create maps, graphics, and inform analysis as par
 Planning Commission in July 2013. Please refer to the Philadelphia Trail Master Plan for further detail on the descriptions of the attributes
 described in the metadata. Inventory includes both existing trails and existing sidepaths, as defined in the metadata. Sidepaths are designated
 by the Streets Department with advisory approval from the Planning Commission, with the exception of side paths on Philadelphia Parks and Recreation property.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/exterior-violation-cleanups.md
+++ b/_datasets/exterior-violation-cleanups.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Dates and locations of when lots were cleaned (removing weeds, debris, etc.)\
   \ through the City of Philadelphia's Community Life Improvement Program."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/farmers-markets-locations.md
+++ b/_datasets/farmers-markets-locations.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 215-686-5259
 notes: "Locations of farmers markets in Philadelphia.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "\r\n"

--- a/_datasets/fatal-crashes.md
+++ b/_datasets/fatal-crashes.md
@@ -19,7 +19,7 @@ notes: "This data set shows all fatal crashes and their investigative outcomes f
   \ involves further investigation to confirm initial reports. If you want to analyze\
   \ the location of crashes in Philadelphia, use OTIS' dataset. If you want to understand\
   \ the investigative outcomes of crashes, use the PPD dataset.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Vision Zero dashboard on reducing traffic deaths. 

--- a/_datasets/fema-flood-plain.md
+++ b/_datasets/fema-flood-plain.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Federal Emergency Management Administration (FEMA) data clipped to Philadelphia. Please note, FEMA is moving away from solely using '100-year' and '500-year'
   flood terminology by emphasizing the more accurate and technical phrase '1-percent annual chance flood' for a 100-year flood and '0.2-percent annual chance flood'
   for a 500-year flood, focusing on the probability of occurrence rather than the time frame implied by the 'year' designation."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: '' 

--- a/_datasets/fire-department-facilities.md
+++ b/_datasets/fire-department-facilities.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.phila.gov/fire/
 maintainer_phone: null
 notes: "Locations of Philadelphia Fire Department stations. Data originates from the\
   \ City of Philadelphia Fire Department.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "Update Frequency:  as needed\r\n"

--- a/_datasets/flickr-phila-only.md
+++ b/_datasets/flickr-phila-only.md
@@ -16,7 +16,7 @@ notes: 'Flick is an online, interactive photo database, where users can search f
   and an API. With free registration, users can also upload their own photos, create
   profiles, edit, comment, and participate in forum/group culture for non-commercial use.
   Commercial use requires a negotiated agreement.'
-opendataphilly_rating: null
+modified: null
 organization: Flickr
 resources:
 - description: ''

--- a/_datasets/flood-hazard-zone-lines.md
+++ b/_datasets/flood-hazard-zone-lines.md
@@ -15,7 +15,7 @@ notes: 'Data developed by the Federal Emergency Management Agency (FEMA) with in
   digital maps and attribute data.  Risk classifications used in the data are: 1%
   annual-chance flood event; 0.2% annual-chance flood event; and areas of minimal
   flood risk. '
-opendataphilly_rating: null
+modified: null
 organization: Federal Insurance and Mitigation Administration (FEMA)
 resources:
 - description: ''

--- a/_datasets/flu-shot-clinic-schedule-and-locations.md
+++ b/_datasets/flu-shot-clinic-schedule-and-locations.md
@@ -10,7 +10,7 @@ maintainer_phone: 215-685-6458
 notes: "Flu shot clinic schedule and locations for the City of Philadelphia. Locations\
   \ include Philadelphia Department of Public Health District Health Centers, federally\
   \ qualified health centers and community flu clinics.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Annually'

--- a/_datasets/foobooz-reviews.md
+++ b/_datasets/foobooz-reviews.md
@@ -12,7 +12,7 @@ maintainer_link: http://philadelphia.foobooz.com/
 maintainer_phone: 215-564-7700
 notes: An RSS feed of reviews and features about Philadelphia restaurants/bars and
   Philadelphia-related food culture developments.
-opendataphilly_rating: null
+modified: null
 organization: Foobooz
 resources:
 - description: ''

--- a/_datasets/free-food-sites.md
+++ b/_datasets/free-food-sites.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "The City of Philadelphia Office of Children and Families (OCF) partners with local food banks to find locations in the city for meal sites. The food banks provide information
   such as address, hours of operation, and eligibility that OCF enters to feed the meal site finder application. As needed,
   OCF updates the active status of each site."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'An online app to find free food and meal sites near the address you enter.'

--- a/_datasets/free-library-of-philadelphia-rss-feeds.md
+++ b/_datasets/free-library-of-philadelphia-rss-feeds.md
@@ -12,7 +12,7 @@ maintainer_phone: 215-686-5322
 notes: "The library maintains several RSS feeds: Author Events, Free Library Blog,\
   \ Free Library Podcast, Book Reviews, and Digital Collections. \r\n\r\nYou can also\
   \ build a custom RSS feed: http://libwww.freelibrary.org/rss/rssmenu.cfm "
-opendataphilly_rating: '3'
+modified: null
 organization: Free Library of Philadelphia
 resources:
 - description: ''

--- a/_datasets/free-meals.md
+++ b/_datasets/free-meals.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "This dataset and app provide the locations of sites where the public can access free food, nutrition services, and public benefits. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/free-wifi.md
+++ b/_datasets/free-wifi.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "These dataset, dashboard and app tools identify what city-owned sites have free public Wi-Fi available. Between 2025 and 2026, all of    these sites are slated to receive fiber install and Meraki Wi-Fi routers that greatly increase the speed and quality of available Wi-Fi. The   
  dataset and dashboard notes what sites have had this install completed, among other amenities available at each site."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'An app to find free Wi-fi at City-owned locations.'

--- a/_datasets/greater-philadelphia-geohistory-network.md
+++ b/_datasets/greater-philadelphia-geohistory-network.md
@@ -18,7 +18,7 @@ notes: "The Greater Philadelphia GeoHistory Network contains geographic material
   \ in conjunction with a current streets overlay.\r\n\r\nThe historic maps in the\
   \ map viewer are available as tile services for appropriate projects - contact the\
   \ project for further information."
-opendataphilly_rating: '5'
+modified: null
 organization: "Athen\xE6um of Philadelphia"
 resources:
 - description: ''

--- a/_datasets/greatschools-phila-only.md
+++ b/_datasets/greatschools-phila-only.md
@@ -20,7 +20,7 @@ notes: 'GreatSchools is an online database of school locations and relevant info
   interactivity and extra privileges (comment/review capability; participation in
   community forum, customized, detailed grade-by-grade tips; and in-depth article
   access.) '
-opendataphilly_rating: null
+modified: null
 organization: GreatSchools.org
 resources:
 - description: ''

--- a/_datasets/green-stormwater-infrastructure-gsi-planning-parcels.md
+++ b/_datasets/green-stormwater-infrastructure-gsi-planning-parcels.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: PWD Parcels with fields added that help categorize parcels by Green Stormwater
   Infrastructure (GSI) Planning program and standardize ownership or ownership category
   and summarize impervious cover by surface type.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/green-stormwater-infrastructure-planning-districts.md
+++ b/_datasets/green-stormwater-infrastructure-planning-districts.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "District planning areas for Green City, Clean Waters stormwater management\
   \ strategic planning. \r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/green-stormwater-infrastructure-private-projects.md
+++ b/_datasets/green-stormwater-infrastructure-private-projects.md
@@ -11,7 +11,7 @@ notes: "Private Green Stormwater Infrastructure Project data in a tabular relati
   \ database. Location point data is digitized manually with a tracking number. Tabular\
   \ data is queried and joined to point feature class before export to GEODB2 SDE\
   \ databases."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/green-stormwater-infrastructure-public-projects.md
+++ b/_datasets/green-stormwater-infrastructure-public-projects.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Point and line geometric features representing planned and completed Green\
   \ Stormwater Infrastructure (GSI).\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/health-centers.md
+++ b/_datasets/health-centers.md
@@ -8,7 +8,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 215-686-5259
 notes: "The location of primary care health centers.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "\r\n"

--- a/_datasets/health-of-the-city.md
+++ b/_datasets/health-of-the-city.md
@@ -15,7 +15,7 @@ notes: "The Health of the City report summarizes data on community health in Phi
   \ through interactive charts and maps. The Health of the City table contains aggregate\
   \ metrics on population statistics, social determinants of health, and health outcomes\
   \ that were used to build this report."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'An app of maps and charts showing the health of the city data.'

--- a/_datasets/healthy-chinese-takeout.md
+++ b/_datasets/healthy-chinese-takeout.md
@@ -22,7 +22,7 @@ Healthy Chinese Takeout participants as of 2/5/15.The Philadelphia Healthy Chine
   \ other retailers. To date, 200 Chinese take-out restaurants have enrolled in the\
   \ initiative, participated in a low-sodium healthy cooking training with a professional\
   \ chef, and received education about complying with the Tobacco Youth Sales Law."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/healthy-start-community-resource-centers.md
+++ b/_datasets/healthy-start-community-resource-centers.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Street location, hours and contact information of PDPH-affiliated HealthyStart\
   \ Community Resource Centers."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/heat-vulnerability-by-census-tract.md
+++ b/_datasets/heat-vulnerability-by-census-tract.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Describes heat vulnerability by census tract incorporating exposure and sensitivity\
   \ indicators."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: By Census Tracy (CT)

--- a/_datasets/highway-districts.md
+++ b/_datasets/highway-districts.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Please note that the dataset below is a snapshot of data captured at one time\
   \ and does not receive regular updates.\r\n\r\nThe Highway Districts dataset shows\
   \ the boundaries of highway districts used for managing maintenance of roads. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/highway-sections.md
+++ b/_datasets/highway-sections.md
@@ -15,7 +15,7 @@ notes: "This layer delineates the fifty-six sections of the Highway Division of 
   \ and maintaining of the streets within each of the six districts. Examples of maintenance\
   \ include: paving, snow removal, concrete maintenance, and the monitoring/repairing\
   \ of ditches and potholes.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/highway-subsections.md
+++ b/_datasets/highway-subsections.md
@@ -12,7 +12,7 @@ notes: "The subsection layer was developed to aid the Highway Division in the pl
   \ organizing, and maintaining of the streets within each of the fifty-six sections.\
   \  Examples include: paving, snow removal, concrete maintenance, and the monitoring/repairing\
   \ of ditches and potholes."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/historic-maps.md
+++ b/_datasets/historic-maps.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Data includes historic maps of the City of Philadelphia that are shared in [Atlas.phila.gov](https://atlas.phila.gov/),
   allowing users to switch between current imagery and historic maps."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ArcGIS Online (AGO) basemap of this imagery. This raster was created

--- a/_datasets/historic-philadelphia-zoning.md
+++ b/_datasets/historic-philadelphia-zoning.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: 'The City of Philadelphia made a major revision of the zoning code and base maps in 2012. 
   These shapefiles provide a few historic versions of zoning data up to the time of the zoning code change.'
-opendataphilly_rating: null
+modified: null
 organization: OpenDataPhilly
 resources:
 - description: ''

--- a/_datasets/historic-political-wards-divisions.md
+++ b/_datasets/historic-political-wards-divisions.md
@@ -16,7 +16,7 @@ notes: 'Election results are published at the Ward and Ward-Division levels.
   In addition, some results from open records requests to teh City of Philadelphia.
   Data has been collected for 2003 to 2020.
   Attribute tables were modified to match across all years.'
-opendataphilly_rating: null
+modified: null
 organization: OpenDataPhilly
 resources:
 - description: ''

--- a/_datasets/historic-streams.md
+++ b/_datasets/historic-streams.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Philadelphia streams as mapped by Charles Ellet in 1842 and Previous study\
   \ of historic streams conducted by PWD.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/historic-streets.md
+++ b/_datasets/historic-streets.md
@@ -9,7 +9,7 @@ maintainer_email: michael.matela@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "To map older streets with historical value in the City of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/hiv-testing-sites.md
+++ b/_datasets/hiv-testing-sites.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: This point layer contains the locations of HIV testing sites in the City of
   Philadelphia.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/homes-saved.md
+++ b/_datasets/homes-saved.md
@@ -18,7 +18,7 @@ notes: "To prevent homeowners from becoming homeless due to foreclosure, the Cit
   \ to foreclosure with City-funded housing counseling, outreach, a hotline and legal\
   \ assistance. Working together, the City and the Court have created and implemented\
   \ a national model.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/housing-counseling-agencies.md
+++ b/_datasets/housing-counseling-agencies.md
@@ -15,7 +15,7 @@ notes: "OHCD has long supported neighborhood-based and citywide organizations of
   \ provided by these agencies include mortgage counseling, default and delinquency\
   \ counseling, tenant support and housing consumer education. Through these services\
   \ prospective homeowners can avoid predatory loans, a significant cause of foreclosure."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/hydrology.md
+++ b/_datasets/hydrology.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "Locations of surface water features (rivers, creeks, ponds, reservoirs) and\
   \ water beneath city bridges and adjacent to city borders. Separate files are available\
   \ for each waterbody (and watershed) in KML form, or as a whole in Shapefile form."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/impervious-surfaces.md
+++ b/_datasets/impervious-surfaces.md
@@ -12,7 +12,7 @@ maintainer_phone: 215-686-8287
 notes: "This is one of the planimetric coverages developed as part of the aerial survey\
   \ project of 1996 and updated using new aerial photography collected between 25\
   \ March 2004 and 23 April 2004."
-opendataphilly_rating: '2'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/indego-bike-share-stations.md
+++ b/_datasets/indego-bike-share-stations.md
@@ -13,7 +13,7 @@ maintainer_phone: null
 notes: "Data relating to the Indego BikeShare program, including station locations\
   \ and the number of available bikes. More information about the program is available\
   \ at:\r\nhttps://www.rideindego.com/about/data/"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/indego-bike-share-trips.md
+++ b/_datasets/indego-bike-share-trips.md
@@ -13,7 +13,7 @@ maintainer_phone: null
 notes: "Data relating to the Indego BikeShare program, including station locations\
   \ and the number of available bikes. More information about the program is available\
   \ at: https://www.rideindego.com/about/data/\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/instore-forgivable-loan-program.md
+++ b/_datasets/instore-forgivable-loan-program.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Contains information about the applicant, business, project, and costs. Used\
   \ for tracking completed projects; including tracking amounts paid."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/intersection-controls.md
+++ b/_datasets/intersection-controls.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This layer identifies the active intersection controls for the Street Lighting\
   \ and Traffic Engineering Divisions of the City of Philadelphia Streets Department."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/inventory-of-african-american-historic-sites.md
+++ b/_datasets/inventory-of-african-american-historic-sites.md
@@ -14,7 +14,7 @@ notes: An inventory compiled by the Preservation Alliance for Greater Philadelph
   for each site include Site Name, Address, Neighborhood, Significance, Site Type,
   Date Built, and Architect.   This inventory of 400+ structures includes churches,
   schools, businesses, homes, clubs, benevolent associations, and more.
-opendataphilly_rating: null
+modified: null
 organization: Preservation Alliance for Greater Philadelphia
 resources:
 - description: Report including a table of African American Historic Sites

--- a/_datasets/inventory-of-historic-religious-properties.md
+++ b/_datasets/inventory-of-historic-religious-properties.md
@@ -27,7 +27,7 @@ notes: "Founded as William Penn's \"Holy Experiment,\" Philadelphia has a centur
   \ 1960.\r\n\r\nData elements include:  current congregation, original congregation,\
   \ address, year of construction, original architect and whether or not the build\
   \ is on the Philadelphia or National Historic Registers.\r\n"
-opendataphilly_rating: null
+modified: null
 organization: Preservation Alliance for Greater Philadelphia
 resources:
 - description: By University of Pennsylvania graduate student, Molly Lester in 2011

--- a/_datasets/land-use.md
+++ b/_datasets/land-use.md
@@ -14,7 +14,7 @@ notes: "City of Philadelphia land use as ascribed to individual parcel boundarie
   \ nine major classifications of land use (2-digit code), and where possible a more\
   \ narrowly defined sub-classification (3-digit code). The land use feature class\
   \ has been field checked and corrected for the following Planning Districts. "
-opendataphilly_rating: '5'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/landcare-program.md
+++ b/_datasets/landcare-program.md
@@ -10,7 +10,7 @@ maintainer_email: darshna.patel@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "The Philadelphia LandCare layer is an inventory of all vacant parcels that have received the \"Clean and Green\" stabilization treatment and are currently under maintenance contract with the Pennsylvania Horticultural Society, funded by the City of Philadelphia’s Division of Housing and Community Development. Every spring and fall, additional vacant parcels are stabilized and then added to the maintenance inventory the following year. The parcels in this layer are based off the PARCEL_PWD layer, supplied by the Philadelphia Water Department."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/language-services-usage.md
+++ b/_datasets/language-services-usage.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This dataset tracks usage of the City's language access services through contracts\
   \ with external vendors for translation and interpretation."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/large-building-energy-benchmarking-data.md
+++ b/_datasets/large-building-energy-benchmarking-data.md
@@ -12,7 +12,7 @@ notes: "This dataset contains annual building and performance data for those pro
   \ required to report. Property data is pulled from the Office of Property Assessment.\
   \ Energy and water data is self-reported by building owners using the EPA Portfolio\
   \ Manager tool. This data will be updated annually.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Mapping and visualization application developed by the Office

--- a/_datasets/lead-paint-certs.md
+++ b/_datasets/lead-paint-certs.md
@@ -15,7 +15,7 @@ notes: "The Philadelphia Lead Paint Disclosure and Certification Law requires ow
   in the city by OPA account number, based on the information submitted to the Lead and Healthy Homes Program. Note 
   that the certification information must be consistent with the details of the rental license in order for the rental 
   license to be granted."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/leaf-collection-areas.md
+++ b/_datasets/leaf-collection-areas.md
@@ -9,7 +9,7 @@ maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "To identify boundaries for City Leaf Collection Services.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/leaf-dropoff-sites.md
+++ b/_datasets/leaf-dropoff-sites.md
@@ -8,7 +8,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: 'Bagged leaf dropoff locations operated by the Streets Department during 7-week period in autumn.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-appeals-of-code-violations-and-permit-refusals.md
+++ b/_datasets/licenses-and-inspections-appeals-of-code-violations-and-permit-refusals.md
@@ -19,7 +19,7 @@ notes: "The Department of Licenses and Inspections accepts applications for appe
   \ could have multiple appeal types, so those are provided as a dataset below as\
   \ well. \r\n\r\nThe Board Decisions datasets shows the decisions made by the Appeal\
   \ Boards (LIRB, ZBA, BBS).\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-building-and-zoning-permits.md
+++ b/_datasets/licenses-and-inspections-building-and-zoning-permits.md
@@ -22,7 +22,7 @@ notes: "The Department of Licenses & Inspections reviews construction plans and 
   \ the API links to access this data. You can learn more about how to use the API\
   \ at Carto\u2019s SQL API site and in the Carto guide in the section on making calls\
   \ to the API.**"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-building-certifications.md
+++ b/_datasets/licenses-and-inspections-building-certifications.md
@@ -22,7 +22,7 @@ notes: "Certain buildings in the City of Philadelphia require periodic inspectio
   \ This dataset contains records related to these building certifications.\r\n\r\n\
   You can find out more information about [fire protection certifications](https://www.phila.gov/departments/department-of-licenses-and-inspections/inspections/fire-protection-certifications/)\
   \ and [maintenance inspections](https://www.phila.gov/departments/department-of-licenses-and-inspections/inspections/maintenance-inspections/)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-business-licenses.md
+++ b/_datasets/licenses-and-inspections-business-licenses.md
@@ -18,7 +18,7 @@ notes: "Information regarding applications for licenses required by the City to 
   \ includes license application type, applicant, property for which the license would\
   \ be issued, application date, issue date, and expiration date. Data is accurate;\
   \ however, it may be misinterpreted by an unfamiliar user.\r\n\r\n"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-case-investigations.md
+++ b/_datasets/licenses-and-inspections-case-investigations.md
@@ -16,7 +16,7 @@ notes: "All investigations completed on a property with property maintenance vio
   \ the API links to access this data. You can learn more about how to use the API\
   \ at Carto\u2019s SQL API site and in the Carto guide in the section on making calls\
   \ to the API.**"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-clean-and-seal.md
+++ b/_datasets/licenses-and-inspections-clean-and-seal.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "Address, date of abatement, and more for properties that have been cleaned\
   \ and sealed by the L&I Clean & Seal Unit.\r\n\r\n\r\
   \n"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-code-violations.md
+++ b/_datasets/licenses-and-inspections-code-violations.md
@@ -17,7 +17,7 @@ notes: "Violations issued by the Department of Licenses and Inspections in refer
   \ use the API at Carto\u2019s SQL API site and in the Carto guide in the section\
   \ on making calls to the API.**\r\
   \n"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-commercial-activity-licenses.md
+++ b/_datasets/licenses-and-inspections-commercial-activity-licenses.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Commercial Activity Licenses are required by entities doing business in the\
   \ City of Philadelphia. Information includes license number, application date, issuance\
   \ date, applicant information, business entity name and other related information."
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-complaints.md
+++ b/_datasets/licenses-and-inspections-complaints.md
@@ -16,7 +16,7 @@ notes: "Complaints that were entered via 311 or by an individual in the departme
   \ table represents a single 'call'. Calls are sometimes bunched into one 'Complaint'\
   \ all sharing the same unique number.\r\n\r\n\r\
   \n"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-district-offices.md
+++ b/_datasets/licenses-and-inspections-district-offices.md
@@ -13,7 +13,7 @@ notes: "Location and contact information for the L&I district offices.\r\n\r\nFo
   \ all L&I data related inquiries contact ligisteam@phila.gov. For all other L&I\
   \ related services (including eCLIPSE troubleshooting) please contact Philly311:\r\
   \n*Inside City Limits: 311\r\n*Outside City Limits: 215-686-8686"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-districts.md
+++ b/_datasets/licenses-and-inspections-districts.md
@@ -13,7 +13,7 @@ maintainer_phone: null
 notes: "District Boundaries for the Department of Licenses & Inspections are pre 2014.\r\
   \nDistricts Broad refers to the five districts which contain their own district\
   \ offices and are a method the department uses to assign and analyze work."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-property-history.md
+++ b/_datasets/licenses-and-inspections-property-history.md
@@ -9,7 +9,7 @@ maintainer_email: null
 maintainer_link: null
 maintainer_phone: null
 notes: "This dataset documents the history of permits, licenses, violations, and appeals for each property in the City."
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-trade-licenses.md
+++ b/_datasets/licenses-and-inspections-trade-licenses.md
@@ -13,7 +13,7 @@ notes: "Information regarding individuals who have applied for trades licenses s
   \ as General Contractor, Master Plumber, and more. Information includes the individual's\
   \ name, license number, license status issue date, expiration date, company name,\
   \ and revenue code.\r\n\r\n"
-opendataphilly_rating: null
+modified: R/P1D
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/lidar-las-data.md
+++ b/_datasets/lidar-las-data.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "LiDAR and LAS data was gathered for the City of Philadelphia in April 2008,\
   \ April 2010, 2015, April 2018, and 2022."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/litter-index.md
+++ b/_datasets/litter-index.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "The Litter Index is used to compare the relative cleanliness of different\
   \ areas of the city of Philadelphia. This data will be updated annually."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/major-watersheds-philadelphia.md
+++ b/_datasets/major-watersheds-philadelphia.md
@@ -14,7 +14,7 @@ notes: "Polygon feature class representing major watersheds in Philadelphia. Dat
   \ model) using ArcHydro watershed extraction tools. Major Watersheds are dissolved\
   \ from subshed boundaries which reflect surface flow in relationship to stormwater\
   \ inlets and outfalls.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/major-watersheds-regional.md
+++ b/_datasets/major-watersheds-regional.md
@@ -15,7 +15,7 @@ notes: "Polygon feature class representing major watersheds in Philadelphia. Dat
   \ model) using ArcHydro watershed extraction tools. Major Watersheds are dissolved\
   \ from subshed boundaries which reflect surface flow in relationship to stormwater\
   \ inlets and outfalls.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/market-value-assessment.md
+++ b/_datasets/market-value-assessment.md
@@ -13,7 +13,7 @@ notes: "The Reinvestment Fund’s (TRF) Market Value Analysis (MVAs) is a tool r
   with local experts. With an MVA, public officials and private actors can more precisely target intervention strategies in stressed
   markets and support sustainable growth in stronger markets. [Visit TRF's MVA analysis](https://www.reinvestment.com/research/market-value-analysis/)
   page for more information."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/mid-century-modern-architecture-inventory.md
+++ b/_datasets/mid-century-modern-architecture-inventory.md
@@ -18,7 +18,7 @@ notes: Mid-century modern architecture and buildings of the recent past are enjo
   or other purposes, nor does its absence imply a lack of significance. Rather, the
   list is meant to illustrate the breadth and depth of design from an era often overshadowed
   by earlier periods and styles.
-opendataphilly_rating: null
+modified: null
 organization: Preservation Alliance for Greater Philadelphia
 resources:
 - description: Report written by Malcolm Clendenin and edited by Emily T. Cooperman

--- a/_datasets/municipal-waste-operations.md
+++ b/_datasets/municipal-waste-operations.md
@@ -13,7 +13,7 @@ notes: Data includes point-locations and names of Municipal Waster Operations, o
   Waste Management Municipal Waste Program. Related subtypes included are composting
   facilities, abandoned landfills, active landfills, and transfer stations.  Originally
   released in 2006.  Updated quarterly.
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Environmental Protection
 resources:
 - description: ''

--- a/_datasets/neighborhood-advisory-committees-nacs.md
+++ b/_datasets/neighborhood-advisory-committees-nacs.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "DHCD\u2019s Neighborhood Advisory Committee (NAC) Program offers community-based\
   \ non-profit organizations the opportunity to lead and engage neighborhood residents\
   \ in activities that support the City\u2019s core objectives.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/neighborhood-energy-centers.md
+++ b/_datasets/neighborhood-energy-centers.md
@@ -13,7 +13,7 @@ notes: "DHCD supports the Energy Coordinating Agency\u2019s (ECA) Neighborhood E
   \ Centers, through which residents can complete applications to seek bill payment\
   \ assistance, learn how to conserve water, gas and electricity, and obtain energy\
   \ counseling."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/neighborhood-food-retail.md
+++ b/_datasets/neighborhood-food-retail.md
@@ -15,7 +15,7 @@ notes: "This dataset is derived from the Neighborhood Food Retail in Philadelphi
   \ looks at neighborhood availability of \"high-produce supply stores\u201D (e.g.,\
   \ supermarkets, produce stores, farmers\u2019 markets) in relation to \u201Clow-produce\
   \ supply stores\u201D (like dollar stores, pharmacies, and convenience stores)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/neighborhood-resources.md
+++ b/_datasets/neighborhood-resources.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Dataset with the contact information for Housing Counseling Agencies, Neighborhood\
   \ Advisory Committees, and Neighborhood Energy Centers.\r\n\r\n."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/non-thru-streets-for-trucks.md
+++ b/_datasets/non-thru-streets-for-trucks.md
@@ -12,7 +12,7 @@ maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "To map streets with no through trucks in the City of Philadelphia. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/now-then-modern-and-historical-images-of-philadelphia.md
+++ b/_datasets/now-then-modern-and-historical-images-of-philadelphia.md
@@ -12,7 +12,7 @@ notes: 'Now & Then provides access to historic and contemporary photographs of P
   When accessed via a location-aware web browser, the app loads photographs taken
   near the user''s location. Historic photographs are from the PhillyHistory.org database.
   Contemporary photographs are from Panaramio.com. '
-opendataphilly_rating: null
+modified: null
 organization: Skookul.com
 resources:
 - description: ''

--- a/_datasets/nowdata-noaa-online-weather-data.md
+++ b/_datasets/nowdata-noaa-online-weather-data.md
@@ -11,7 +11,7 @@ maintainer_phone: (609) 261-6600
 notes: 'The purpose of this dataset is to record weather to help people get quick
   access to climate data. Additionally, this dataset is useful for background information
   or looking at yearly differences. '
-opendataphilly_rating: null
+modified: null
 organization: NOAA
 resources:
 - description: ''

--- a/_datasets/oeo-registry-of-certified-minoritywomendisable-owned-business-enterprises.md
+++ b/_datasets/oeo-registry-of-certified-minoritywomendisable-owned-business-enterprises.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "A database of all Minority/Women/Disable Owned (MWD) owned businesses that\
   \ are registered with the City of Philadelphia's Office of Economic Opportunity\
   \ (OEO)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/online-citizens-guide.md
+++ b/_datasets/online-citizens-guide.md
@@ -16,7 +16,7 @@ notes: 'An online polling place and elected official look-up tool that enables u
   can also download results as text files. Data is drawn from the Committee of Seventy
   as well as the Philadelphia City Council, the Philadelphia City Planning Commission
   (PCPC), and other city of Philadelphia agencies. '
-opendataphilly_rating: null
+modified: null
 organization: Committee of Seventy
 resources:
 - description: ''

--- a/_datasets/openmaps.md
+++ b/_datasets/openmaps.md
@@ -25,7 +25,7 @@ maintainer_phone: null
 notes: "Explore Philadelphia's most popular open geographic data in one easy to use\
   \ mapping tool. This tool was built by the City's Office of Innovation and Technology's\
   \ CityGeo team."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/outdoor-advertising.md
+++ b/_datasets/outdoor-advertising.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Locational and relevant attribute data pertaining to billboard and outdoor\
   \ advertising locations throughout the City of Philadelphia.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pa-ambulatory-surgical-centers.md
+++ b/_datasets/pa-ambulatory-surgical-centers.md
@@ -12,7 +12,7 @@ notes: "Data includes location points of Pennsylvania ambulatory surgical center
 facilities for surgeries to be performed on a person who is admitted to and
 discharged from the location on the same day."
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-birth-centers.md
+++ b/_datasets/pa-birth-centers.md
@@ -15,7 +15,7 @@ were made to confirm the rooftop location of each birth facility. The accuracy o
 geocoding is available in Geocoding Certainty attribute field (Geocoding Certainty: 
 Rooftop="00", Street="01", Zip Centroid="04", Not geocoded="99").'
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-community-mental-health-facilities.md
+++ b/_datasets/pa-community-mental-health-facilities.md
@@ -15,7 +15,7 @@ When possible, efforts were made to confirm the rooftop location of each communi
 health center. The accuracy of geocoding is available in Geocoding Certainty attribute field 
 (Geocoding Certainty: Rooftop="00", Street="01", Zip Centroid="04", Not geocoded="99").'
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-dot-at-grade-intersections.md
+++ b/_datasets/pa-dot-at-grade-intersections.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Locations of Pennsylvania At-Grade Intersections as maintained by the PA Dept of Transportation'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-bridges.md
+++ b/_datasets/pa-dot-bridges.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Bridge locations within Pennsylvania'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-congressional-districts.md
+++ b/_datasets/pa-dot-congressional-districts.md
@@ -14,7 +14,7 @@ notes: 'Boundaries of United States Congressional legislative boundaries for Pen
   Commissions, Elections and Legislation Pennsylvania Dept. of State.
   The current layers are attributed with the current legislator name, party affiliation and home county.'
   
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-drain-pipes.md
+++ b/_datasets/pa-dot-drain-pipes.md
@@ -10,7 +10,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Locations and attributes of drainage pipe structures that intersect with a state route'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-interstate-mile-markers.md
+++ b/_datasets/pa-dot-interstate-mile-markers.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Point locations of Pennsylvania Interstate mile markers'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-local-roads.md
+++ b/_datasets/pa-dot-local-roads.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Public roads, including those not maintained by the PA Dept. of Transportation.'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-municipality-boundaries.md
+++ b/_datasets/pa-dot-municipality-boundaries.md
@@ -13,7 +13,7 @@ notes: 'Boundaries of municipalities within Pennsylvania as delineated for the P
 Type 10 general highway maps. Additional information comes from the Pennsylvania Bureau of 
 Municipal Services. This layer contains all classifications of municipality including 
 first and second class townships, boroughs, cities and the town.'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-rail-lines.md
+++ b/_datasets/pa-dot-rail-lines.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Rails Lines within Pennsylvania'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-railroad-crossings.md
+++ b/_datasets/pa-dot-railroad-crossings.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Pennsylvania Railroad Crossing Points of Intersection'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-school-districts.md
+++ b/_datasets/pa-dot-school-districts.md
@@ -10,7 +10,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'School districts as defined by Pennsylvania Department of Transportation, Bureau of Planning and Research, Cartographic Information Division'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-state-house-of-representatives-districts.md
+++ b/_datasets/pa-dot-state-house-of-representatives-districts.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Data includes boundaries of Pennsylvania House of Representatives Legislative
   Districts, along with name and party affiliation of each district''s legislator.'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-state-roads.md
+++ b/_datasets/pa-dot-state-roads.md
@@ -12,7 +12,7 @@ notes: 'State-owned and maintained public roads within Pennsylvania as extracted
 the PENNDOT Roadway Management System (RMS). Includes fields describing pavement type, 
 traffic volumes and other information. The Administrative version is used for reporting 
 purposeslike the federal aid system and federal functional classification.'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-state-senate-districts.md
+++ b/_datasets/pa-dot-state-senate-districts.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Data includes polygon boundaries of Pennsylvania Senate Legislative Districts,
   along with name and party affiliation of each district''s legislator.  '
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-traffic-counts.md
+++ b/_datasets/pa-dot-traffic-counts.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'Traffic volumes; measured and calculated amounts of vehicle traffic that travel the sections of road.'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-dot-transportation-improvement-projects.md
+++ b/_datasets/pa-dot-transportation-improvement-projects.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: 717-772-3305
 notes: 'PennDOT Transportation Improvement Projects as derived from the Multi-Modal Project Management System (MPMS).'
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Transportation
 resources:
 - description: ''

--- a/_datasets/pa-drug-alcohol-treatment-facilities.md
+++ b/_datasets/pa-drug-alcohol-treatment-facilities.md
@@ -14,7 +14,7 @@ notes: 'The PA Drug Alcohol Treatment Facilities dataset includes facilities tha
   The accuracy of geocoding is available in Geocoding Certainty attribute field (Geocoding Certainty: 
   Rooftop="00", Street="01", Zip Centroid="04", Not geocoded="99").'
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-high-resolution-tree-canopy.md
+++ b/_datasets/pa-high-resolution-tree-canopy.md
@@ -17,7 +17,7 @@ notes: "This dataset maps tree canopy for the state Pennsylvania at a 1m resolut
   \ etc.   Please note that this dataset is independent from those areas we have mapped\
   \ for Urban Tree Canopy (UTC) assessments.  Future releases will integrate these\
   \ two projects."
-opendataphilly_rating: null
+modified: null
 organization: University of Vermont Spatial Analysis Lab
 resources:
 - description: 2.3 GB zip file of tree canopy as a 1m resolution raster data set

--- a/_datasets/pa-home-health-agencies.md
+++ b/_datasets/pa-home-health-agencies.md
@@ -13,7 +13,7 @@ notes: "Locations of home health care agencies in Pennsylvania, according to the
   in providing skilled nursing services, home health aides, and other therapeutic
   services, such as physical therapy, in patients' homes."
   
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-hospices.md
+++ b/_datasets/pa-hospices.md
@@ -11,7 +11,7 @@ maintainer_phone: 717-782-2448
 notes: "Locations of Pennsylvania hospices, according to the PA Department of Health's
   quality assurance database. A hospice is a home providing care for the sick or terminally ill."
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-hospitals.md
+++ b/_datasets/pa-hospitals.md
@@ -15,7 +15,7 @@ notes: 'The PA Hospitals layer contains the latitude and longitude coordinates o
   attribute field (Geocoding Certainty: Rooftop="00", Street="01", Zip Centroid="04",
   Not geocoded="99").'
   
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-intermediate-care-facilities.md
+++ b/_datasets/pa-intermediate-care-facilities.md
@@ -16,7 +16,7 @@ rooftop location of each intermediate care facility. The accuracy of geocoding i
 available in Geocoding Certainty attribute field (Geocoding Certainty: Rooftop="00", 
 Street="01", Zip Centroid="04", Not geocoded="99").'
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-medical-marijuana-dispensaries.md
+++ b/_datasets/pa-medical-marijuana-dispensaries.md
@@ -14,7 +14,7 @@ rooftop location of each medical marijuana dispensary. The accuracy of geocoding
 available in Geocoding Certainty attribute field (Geocoding Certainty: Rooftop="00", 
 Street="01", Zip Centroid="04", Not geocoded="99").'
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-nursing-homes.md
+++ b/_datasets/pa-nursing-homes.md
@@ -14,7 +14,7 @@ notes: >
   to confirm the rooftop location of each nursing home. The accuracy of geocoding is 
   available in Geocoding Certainty attribute field (Geocoding Certainty: Rooftop="00", 
   Street="01", Zip Centroid="04", Not geocoded="99").
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-physical-speech-therapy-facilities.md
+++ b/_datasets/pa-physical-speech-therapy-facilities.md
@@ -15,7 +15,7 @@ physical speech therapists. The accuracy of geocoding is available in Geocoding
 Certainty attribute field (Geocoding Certainty: Rooftop="00", Street="01", 
 Zip Centroid="04", Not geocoded="99"). '
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-psychiatric-residential-treatment-facilities.md
+++ b/_datasets/pa-psychiatric-residential-treatment-facilities.md
@@ -15,7 +15,7 @@ notes: 'The PA Psychiatric Residential Treatment Facilities dataset includes fac
   accuracy of geocoding is available in Geocoding Certainty attribute field 
   (Geocoding Certainty: Rooftop="00", Street="01", Zip Centroid="04", Not geocoded="99").'
 
-opendataphilly_rating: null
+modified: null
 organization: PA Department of Health
 resources:
 - description: ''

--- a/_datasets/pa-state-house-of-representatives-districts.md
+++ b/_datasets/pa-state-house-of-representatives-districts.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Please refer to [PA's open data for the State House Representative Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-House-Districts-Boundaries/in5u-czi3)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources: []
 schema: philadelphia

--- a/_datasets/parking-locator.md
+++ b/_datasets/parking-locator.md
@@ -16,7 +16,7 @@ notes: 'An online parking facility information and look-up tool developed by the
   and popular destination markers. Clicking on each location-point, yields information
   about different rates, type of facility (garage/lot), total spaces, distance to
   entered destination, and operator name. '
-opendataphilly_rating: '7'
+modified: null
 organization: Philadelphia Parking Authority
 resources:
 - description: ''

--- a/_datasets/parking-meter-kiosk-inventory.md
+++ b/_datasets/parking-meter-kiosk-inventory.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Raw data dump from the PPA including meter/kiosk manufacturer and model, as\
   \ well as status."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parking-violations.md
+++ b/_datasets/parking-violations.md
@@ -13,7 +13,7 @@ notes: "**Please note that this is a very large dataset. To see all violations, 
   \ can also use the API links to access this data. You can learn more about how to\
   \ use the API at Carto\u2019s SQL API site and in the Carto guide in the section\
   \ on making calls to the API.**"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-and-recreation-out-of-school-time-programs.md
+++ b/_datasets/parks-and-recreation-out-of-school-time-programs.md
@@ -10,7 +10,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Philadelphia Parks and Recreation out-of-school time afterschool programs."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-and-recreation-ppr-trails.md
+++ b/_datasets/parks-and-recreation-ppr-trails.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Linear representation of Philadelphia Parks and Recreation (PPR) trails. Not\
   \ designed for networking."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-recreation-districts.md
+++ b/_datasets/parks-recreation-districts.md
@@ -13,7 +13,7 @@ notes: "Polygon boundaries of Philadelphia Parks and Recreation (PPR) operationa
   \ districts as established by PPR's GIS staff and reviewed, revised, and approved\
   \ by PPR's executive staff. These boundaries were revised from boundaries that were\
   \ in place in prior years.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-recreation-program-sites.md
+++ b/_datasets/parks-recreation-program-sites.md
@@ -14,7 +14,7 @@ maintainer_phone: null
 notes: "Point location features for all PPR Program site locations. This dataset includes\
   \ recreation centers, playgrounds, older adult centers, swimming pools, and environmental\
   \ education centers.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/patco-gtfs.md
+++ b/_datasets/patco-gtfs.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: '[General Transit Feed Specification (GTFS)](https://developers.google.com/transit/gtfs/)
   for the PATCO train schedule.'
-opendataphilly_rating: null
+modified: null
 organization: Port Authority Transit Corporation (PATCO)
 resources:
 - description: GTFS data as a zip file.

--- a/_datasets/paving-plan.md
+++ b/_datasets/paving-plan.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "City of Philadelphia paving plan for 2015 that displays paving project funding,\
   \ City - Local Funding, City - Federal Funding, and State Funding.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pennypack-park-trail-map.md
+++ b/_datasets/pennypack-park-trail-map.md
@@ -14,7 +14,7 @@ notes: "This is a map of trails in Pennypack Park, Lorimer Park and Pennypack Tr
   \ and collected using common GPS watches (Garmin, Polar, etc) GPX data and verifying\
   \ trails visually using high res aerial imagery to accurately adjust to trails.\r\
   \n"
-opendataphilly_rating: null
+modified: null
 organization: Volunteer
 resources:
 - description: "This is a map of trails in Pennypack Park, Lorimer Park and Pennypack\

--- a/_datasets/people-released-to-philadelphia-from-prison-jail.md
+++ b/_datasets/people-released-to-philadelphia-from-prison-jail.md
@@ -16,7 +16,7 @@ notes: "This dataset includes people released to Philadelphia from the Philadelp
   \ the year analyzed. The dataset also only includes people released to Philadelphia\
   \ who have been charged with a criminal non-summary type offense in the Philadelphia\
   \ adult criminal justice system."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Annually'

--- a/_datasets/percent-for-art-locations.md
+++ b/_datasets/percent-for-art-locations.md
@@ -13,7 +13,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Locations and basic information on public art that is part of the Percent\
   \ for Art program. Updated as needed. \r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pha-housing-sites.md
+++ b/_datasets/pha-housing-sites.md
@@ -14,7 +14,7 @@ notes: 'The Philadelphia Housing Authority Housing Sites application is a map of
   by type of development, number of bedrooms, and units with accessibility features.
   The information for each housing site includes the name, location, an image, and
   a link to a fact sheet with additional details. '
-opendataphilly_rating: null
+modified: null
 organization: Philadelphia Housing Authority
 resources:
 - description: ''

--- a/_datasets/philadelphia-architects-and-buildings-project.md
+++ b/_datasets/philadelphia-architects-and-buildings-project.md
@@ -13,7 +13,7 @@ notes: "An online database of architectural and historical information and image
   \ for 35,000+ structures, 110,000 images+ images and maps and biographies of 5,000+\
   \ architects in the 5 county region around Philadelphia.  Development was a collaboration\
   \ between private, academic, and public entities led by the Athen\xE6um of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: "Athen\xE6um of Philadelphia"
 resources:
 - description: ''

--- a/_datasets/philadelphia-artist-census-2018.md
+++ b/_datasets/philadelphia-artist-census-2018.md
@@ -14,7 +14,7 @@ notes: In the Summer of 2018, PhillyStewards released the Philly Artist Census f
   assemble this information was and continues to be to clarify myths from truths about
   the greater Philly artist community.  We received over 500 responses from the Philadelphia
   artist community.
-opendataphilly_rating: null
+modified: null
 organization: Philly Stewards
 resources:
 - description: ''

--- a/_datasets/philadelphia-basemaps.md
+++ b/_datasets/philadelphia-basemaps.md
@@ -10,7 +10,7 @@ maintainer_email: maps@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Basemaps of the Philadelphia area, including from the Department of Records."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-beverage-tax-registered-distributors-and-dealers.md
+++ b/_datasets/philadelphia-beverage-tax-registered-distributors-and-dealers.md
@@ -20,7 +20,7 @@ notes: "**This data has stopped receiving updates. We're working to reestablish 
   \ consented to share their information publicly and thus this list may not be a\
   \ comprehensive list of all who have registered. \r\n\r\n[Find out more about the\
   \ Philadelphia Beverage Tax here](https://www.phila.gov/services/payments-assistance-taxes/business-taxes/philadelphia-beverage-tax/)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-business-dashboard.md
+++ b/_datasets/philadelphia-business-dashboard.md
@@ -18,7 +18,7 @@ notes: "This interactive series of charts and maps was developed to track Philad
   \ Small Businesses\r\n - Pre-pandemic City and Zip Area Profiles\r\n - Pre-pandemic\
   \ Business Owner Profiles\r\n\r\nThe data can be filtered based on industry, location,\
   \ size, and gender."
-opendataphilly_rating: null
+modified: null
 organization: Pew Philadelphia Research and Policy Initiative
 resources:
 - description: Interactive dashboard of business activity in the post-COVID period

--- a/_datasets/philadelphia-child-blood-lead-levels.md
+++ b/_datasets/philadelphia-child-blood-lead-levels.md
@@ -16,7 +16,7 @@ notes: "This dataset includes the number of newly identified (incident) children
   \ is for 2015 and the census tract data is for 2013-2015.\r\n\r\nCell counts with\
   \ missing values are those with less than six observations, which was truncated\
   \ to ensure confidentiality. Cells with values of zero were included."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-code-and-home-rule-charter.md
+++ b/_datasets/philadelphia-code-and-home-rule-charter.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Raw text and other formats available of the City of Philadelphia Municipal\
   \ Code and City Charter.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-crash-points.md
+++ b/_datasets/philadelphia-crash-points.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: Reported crashes in the city of Philadelphia from 2008-2012. Original data
   source is  PennDOT, the data was geocoded and flag table merged with crash locations
   to provide a more complete dataset with incident information.
-opendataphilly_rating: null
+modified: null
 organization: Azavea
 resources:
 - description: "# Philadelphia Crashes - 2012\r\n\r\n### Description  \r\n\r\nCrash\

--- a/_datasets/philadelphia-esl-english-as-a-second-language-class-locations.md
+++ b/_datasets/philadelphia-esl-english-as-a-second-language-class-locations.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Location of English as a Second Language (ESL) classes in Philadelphia. To\
   \ find the best site to visit for ESL classes, or to enroll in training for volunteers\
   \ to become an ESL tutor, please contact the Office of Adult Education at 215-686-5250."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-hospitals.md
+++ b/_datasets/philadelphia-hospitals.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "A list of hospitals and their location in Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-household-internet-assessment-survey.md
+++ b/_datasets/philadelphia-household-internet-assessment-survey.md
@@ -11,7 +11,7 @@ maintainer_email: juliet.fink-yates@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "A survey assessment on home broadband and device access in the City of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-land-cover-raster.md
+++ b/_datasets/philadelphia-land-cover-raster.md
@@ -16,7 +16,7 @@ notes: "The Philadelphia Land Cover Raster provides data on the types of surface
   \ covers another surface type, that area is placed in the tree canopy category.\
   \ The data was gathered with the assistance of the University of Vermont Spatial\
   \ Analysis Laboratory.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Multiple download formats available as well as ArcGIS services and

--- a/_datasets/philadelphia-lobbying-information-system-app.md
+++ b/_datasets/philadelphia-lobbying-information-system-app.md
@@ -17,7 +17,7 @@ notes: "The Philadelphia Lobbying Information System is a searchable database of
   \ The data collected by PLIS is a public record intended to make the legislative\
   \ and executive process more transparent by providing the public with a clear picture\
   \ of all of the outside interests involved in policy discussions."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-neighborhoods.md
+++ b/_datasets/philadelphia-neighborhoods.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: 'This dataset includes neighborhood boundaries for 150+ neighborhoods in Philadelphia.
   The data was gathered from a mix of publicly available maps, including from the City of Philadelphia,
   the City Archives, the Philadelphia Inquirer, and user feedback.'
-opendataphilly_rating: null
+modified: null
 organization: OpenDataPhilly
 resources:
 - description: ''

--- a/_datasets/philadelphia-pennsylvania-state-senatorial-districts.md
+++ b/_datasets/philadelphia-pennsylvania-state-senatorial-districts.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "State Senate Districts boundaries"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources: 
 - description: ''

--- a/_datasets/philadelphia-police-complaint-archive.md
+++ b/_datasets/philadelphia-police-complaint-archive.md
@@ -22,7 +22,7 @@ notes: "Late last year, the City of Philadelphia began posting online certain da
   \ words, the file labeled \"Complaints Against Police March 2018 Data\" was uploaded\
   \ by the City in March 2018 before being replaced the next month.\r\n\r\nThe original\
   \ data are available here: https://www.opendataphilly.org/datasets/police-complaints"
-opendataphilly_rating: null
+modified: null
 organization: Philly Declaration
 resources:
 - description: 'The data on complaints against police uploaded in March 2018. This

--- a/_datasets/philadelphia-properties-and-assessment-history.md
+++ b/_datasets/philadelphia-properties-and-assessment-history.md
@@ -18,7 +18,7 @@ notes: "***Some of the information in the open data files below may not yet refl
   \ on the quality of assessments. \r\n\r\n***This data updates nightly. Please ignore\
   \ the 'created by' date below - the date of August 2015 shows when this webpage,\
   \ not the data, was created.*** "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: "***This data updates nightly. Please ignore the 'created by' date\

--- a/_datasets/philadelphia-public-art-api.md
+++ b/_datasets/philadelphia-public-art-api.md
@@ -18,7 +18,7 @@ notes: "A read-only, RESTful JSON API.\r\nThe core function of the API is to ret
   \ to a HATEOAS model of navigation and the use of the \"links\":{\"rel\":\"X\",\"\
   href\":\"Y\"} structure.\r\nAlso supports a geolocation call which returns a collection\
   \ that is defined by bb and ll URL arguments"
-opendataphilly_rating: null
+modified: null
 organization: Philart.net
 resources:
 - description: Documentation page for the Philadelphia Public Art API.

--- a/_datasets/philadelphia-public-art-philartnet.md
+++ b/_datasets/philadelphia-public-art-philartnet.md
@@ -14,7 +14,7 @@ notes: Philadelphia Public Art @philart.net includes photographs, descriptive in
   exhibits. A search function is also available. An RSS feed provides information
   on new entries and images updates to the database. The site is not affiliated with
   any non-profit, public, or governmental arts organization.
-opendataphilly_rating: null
+modified: null
 organization: Philart.net
 resources:
 - description: ''

--- a/_datasets/philadelphia-registered-historic-districts.md
+++ b/_datasets/philadelphia-registered-historic-districts.md
@@ -15,7 +15,7 @@ notes: "Historic districts listed on the Philadelphia Register. Data was updated
   \ the Philadelphia City Planning Commission in August 2017.  The public can confirm\
   \ a property\u2019s historic status by contacting the Historical Commission at 215-686-7660.\r\
   \n\r\nYou can also download a dataset of the [Historic sites](https://www.opendataphilly.org/datasets/philadelphia-registered-historic-sites)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-registered-historic-properties.md
+++ b/_datasets/philadelphia-registered-historic-properties.md
@@ -15,7 +15,7 @@ notes: "Historic sites listed on the Philadelphia Register. Data was updated by 
   \ Philadelphia City Planning Commission in July 2017.  The public should confirm\
   \ a property\u2019s historic status by contacting the Historical Commission at 215-686-7660.\r\
   \n\r\nYou can also download a dataset of the [Historic districts](https://www.opendataphilly.org/datasets/philadelphia-registered-historic-districts)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-tree-inventory.md
+++ b/_datasets/philadelphia-tree-inventory.md
@@ -9,7 +9,7 @@ maintainer_email: Chris.Park@Phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "A comprehensive inventory of all trees within the limits of the City of Philadelphia. This dataset is a snapshot in time from 2021 and will update yearly."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-universities-and-colleges.md
+++ b/_datasets/philadelphia-universities-and-colleges.md
@@ -12,7 +12,7 @@ notes: "The purpose of this dataset is to provide the geographic locations of th
   \ college and universities in Philadelphia along with their attribute data attached\
   \ to each polygon.\r\n\r\n\r\
   \n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-vital-statistics-mortality-deaths.md
+++ b/_datasets/philadelphia-vital-statistics-mortality-deaths.md
@@ -15,7 +15,7 @@ notes: "Vital Statistics tables that contain aggregate metrics on the mortality 
   \ are provided at the city, planning district, and census tract levels of geography.\
   \ Please refer to [this technical notes document](https://metadata.phila.gov/index.html#home/datasetdetails/61c23fb963d616001ef54695/)\
   \ to access detailed technical notes and variable definitions.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality (births), mortality (deaths), and population for Philadelphia residents.

--- a/_datasets/philadelphia-vital-statistics-natality-births.md
+++ b/_datasets/philadelphia-vital-statistics-natality-births.md
@@ -16,7 +16,7 @@ notes: "Vital Statistics tables that contain aggregate metrics on the natality (
   \ Please refer to the metadata links below for variable definitions and [this technical\
   \ notes document](https://metadata.phila.gov/index.html#home/datasetdetails/61c23fb963d616001ef54695/)\
   \ to access detailed technical notes about the datasets.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality (births), mortality (deaths), and population for Philadelphia residents.

--- a/_datasets/philadelphia-vital-statistics-population-metrics.md
+++ b/_datasets/philadelphia-vital-statistics-population-metrics.md
@@ -15,7 +15,7 @@ notes: "Population metrics are provided at the census tract, planning district, 
   \ at the city and planning district levels of geography.  Please refer to the metadata\
   \ links below for variable definitions and [the technical notes document](https://metadata.phila.gov/index.html#home/datasetdetails/61c23fb963d616001ef54695/)\
   \ to access detailed technical notes and variable definitions.\r\n\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality (births), mortality (deaths), and population for Philadelphia residents.

--- a/_datasets/philadelphia-vital-statistics-social-determinants-of-health-sdoh.md
+++ b/_datasets/philadelphia-vital-statistics-social-determinants-of-health-sdoh.md
@@ -16,7 +16,7 @@ notes: "Social determinants of health metrics at the city and planning district 
   \ and [mortality (deaths)](https://www.opendataphilly.org/datasets/philadelphia-vital-statistics-mortality-deaths)\
   \ by planning district or citywide. [Population metrics](https://www.opendataphilly.org/datasets/philadelphia-vital-statistics-population-metrics)\
   \ are provided at the city, planning district, and census tract levels of geography.\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality (births), mortality (deaths), and population for Philadelphia residents.

--- a/_datasets/philadox-property-documents.md
+++ b/_datasets/philadox-property-documents.md
@@ -16,7 +16,7 @@ notes: "PhilaDox is an online database of documents filed with the City of Phila
   \ can be downloaded as PDFs.\r\n\r\nFull access to PhilaDox records is available\
   \ with a daily, weekly, monthly, or annual subscription. More limited search for\
   \ names and address is available for free public access.\r\n\r\n"
-opendataphilly_rating: '1'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Searchable database of deed and mortgage recordings.  Actual deeds

--- a/_datasets/philaplace.md
+++ b/_datasets/philaplace.md
@@ -17,7 +17,7 @@ notes: PhilaPlace is an online interactive database of both contemporary and his
   communities. Entries in the database are visualized as feature markers in an interactive
   map tool, accompanying the search.  PhilaPlace was developed by the Historical Society
   of Pennsylvania.
-opendataphilly_rating: null
+modified: null
 organization: Historical Society of Pennsylvania
 resources:
 - description: ''

--- a/_datasets/philly-freight-finder.md
+++ b/_datasets/philly-freight-finder.md
@@ -30,7 +30,7 @@ notes: "Freight Data Portal for the Delaware Valley.\r\n\r\nThe Delaware Valley 
   \ across the country. Open Freight App would serve as a self-hosted solution to\
   \ offer these datasets to other planners, economic developers, public officials,\
   \ decision-makers and the general public."
-opendataphilly_rating: null
+modified: null
 organization: Delaware Valley Regional Planning Commission (DVRPC)
 resources:
 - description: Freight mapping and data platform for the Delaware Valley

--- a/_datasets/philly-keyspot-locations.md
+++ b/_datasets/philly-keyspot-locations.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: This is the location and address data of all current KEYSPOT computer labs
   in Philadelphia.
-opendataphilly_rating: null
+modified: null
 organization: Philly KEYSPOTS
 resources:
 - description: This is the location and address data of all current KEYSPOT computer

--- a/_datasets/philly-rising-boundaries.md
+++ b/_datasets/philly-rising-boundaries.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "The boundaries of the four designated pilot areas included in the Philly Rising\
   \ program. Philly Rising focuses on areas with chronic quality of life concerns\
   \ and works with residents and community groups to address neighborhood issues."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/phillyhistoryorg.md
+++ b/_datasets/phillyhistoryorg.md
@@ -18,7 +18,7 @@ notes: "PhillyHistory.org is an online database of historic photographs and maps
   \ topics, and other criteria. Images and maps are associated with a location using\
   \ the database's geocoding feature. Users can create a free account to save images,\
   \ bookmark searches, and submit error reports."
-opendataphilly_rating: '10'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/phlmaps.md
+++ b/_datasets/phlmaps.md
@@ -26,7 +26,7 @@ notes: "The City of Philadelphia's ArcGIS Online organization that hosts referen
   \ to open data releases as feature services and AGO map applications shared with\
   \ the public.  Maintained by the City's Office of Innovation and Technology's CityGeo\
   \ team."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/phor-septa-train-otp.md
+++ b/_datasets/phor-septa-train-otp.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: 'The purpose of this dataset is to report inefficiencies in SEPTA''s regional rail train
   scheduling for use by SEPTA employees and casual train riders. It also documents late trains, which you can use to excuse work lateness.'
 
-opendataphilly_rating: null
+modified: null
 organization: Apps for Phor
 resources:
 - description: 'The dashboard supports date queries'

--- a/_datasets/piers.md
+++ b/_datasets/piers.md
@@ -9,7 +9,7 @@ maintainer_email: LIGISTEAM@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "This represents waterway structures that may require pier certifications."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/planning-districts.md
+++ b/_datasets/planning-districts.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.philaplanning.org
 maintainer_phone: null
 notes: "To illustrate the outlines of the 18 Districts for Philadelphia2035 District\
   \ Plans."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/playstreets-locations.md
+++ b/_datasets/playstreets-locations.md
@@ -14,7 +14,7 @@ notes: "The streets (at the center of platystreet blocks) involved in the PPR Pl
   \ a safe place to play when school is out. A key feature of the program are the\
   \ nutritious meals and snacks provided to children. This is important during the\
   \ summer months when school meals are not available.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-athletic-league-pal-centers.md
+++ b/_datasets/police-athletic-league-pal-centers.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This data was developed for cartographic use -- specifically, as reference\
   \ information for the Police Athletic League."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-districts.md
+++ b/_datasets/police-districts.md
@@ -9,7 +9,7 @@ maintainer_link: http://www.phillypolice.com/
 maintainer_phone: 215-686-1577
 notes: "Police district boundaries. A police Captain is responsible for each district.\
   \ Districts are subdivided into sectors. Several districts are aggregated into divisions."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-divisions.md
+++ b/_datasets/police-divisions.md
@@ -8,7 +8,7 @@ maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null
 maintainer_phone: 215-686-8287
 notes: "Police division boundaries.  Divisions are aggregations of police districts."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-service-areas.md
+++ b/_datasets/police-service-areas.md
@@ -12,7 +12,7 @@ notes: "There are currently 65 Police Service Areas (PSA) boundaries in Philadel
   \ with two to four per District. These boundaries replaced a much smaller boundary,\
   \ Sectors in 2009. In several Districts, PSA's split Sector boundaries and therefore\
   \ a historical comparison would not necessarily be accurate.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-stations.md
+++ b/_datasets/police-stations.md
@@ -8,7 +8,7 @@ maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Locations of Police Stations.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/political-ward-divisions.md
+++ b/_datasets/political-ward-divisions.md
@@ -12,7 +12,7 @@ maintainer_phone: 215-683-4611
 notes: "Boundaries of the ward divisions (subunits of wards) in Philadelphia. The\
   \ first two numbers of a four number division identifier indicates the ward in which\
   \ the specific division is located.\r\n\r\n"
-opendataphilly_rating: '5'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/political-wards.md
+++ b/_datasets/political-wards.md
@@ -13,7 +13,7 @@ notes: "Boundaries of wards (political units) in the City of Philadelphia. Data 
   \ than 10 and no more than 50 divisions. Ward leaders are elected by their party's\
   \ committeepeople. Learn more about Democratic Ward Leaders and Committeepeople\
   \ : http://www.seventy.org/Resources_Ward_Leaders_and_Committeepeople.aspx"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/polling-places.md
+++ b/_datasets/polling-places.md
@@ -12,7 +12,7 @@ notes: "The locations of polling places in Philadelphia, along with parking code
   \ building accessibility code attribute markers. Data is originally provided by\
   \ the Philadelphia City Commissioners and is continuously updated in correspondence\
   \ with the City Commissioners website, www.philadelphiavotes.com."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-adult-exercise-equipment.md
+++ b/_datasets/ppr-adult-exercise-equipment.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Displays the locations of adult exercise equipment located within or are maintained
   by Philadelphia Parks and Recreation (PPR).
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-boat-launches.md
+++ b/_datasets/ppr-boat-launches.md
@@ -13,7 +13,7 @@ notes: "Boat launches across the city are places where boats (kayaks, canoes, an
   \ or motorboats) can be launched onto the Schuylkill River or Delaware River. This\
   \ dataset identifies the boat launches/ramps located on PPR property or boat launches\
   \ PPR administers directly. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-building-structures.md
+++ b/_datasets/ppr-building-structures.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Footprints of buildings and structures located on Philadelphia Parks and Recreation\
   \ (PPR) properties or utilized directly by PPR.\t\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-friends-group.md
+++ b/_datasets/ppr-friends-group.md
@@ -11,7 +11,7 @@ maintainer_email: chris.park@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Friends groups registered with the Philadelphia Parks and Recreation Stewardship team."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-help-locators.md
+++ b/_datasets/ppr-help-locators.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes:
   Point representations of help locators that provide location information to use when calling for emergency services
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
   - description: ''

--- a/_datasets/ppr-hydration-stations.md
+++ b/_datasets/ppr-hydration-stations.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Locations of hydration station and water fountains on or near Philadelphia
   Parks and Recreation (PPR) assets.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-permittable-space.md
+++ b/_datasets/ppr-permittable-space.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Locations within PPR that are permittable based on PPR team. Feature designed\
   \ to link with Permitting Application for PPR. BETA Version.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-picnic-sites.md
+++ b/_datasets/ppr-picnic-sites.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Displays the locations of picnic sites located within Philadelphia Parks and
   Recreation boundaries. Picnic sites are denoted as any location with a picnic table.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-playgrounds.md
+++ b/_datasets/ppr-playgrounds.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: Displays the locations of playgrounds within PPR Boundaries. Playgrounds ARE
   designated as similar age range equipment within a definable distance (not each
   piece of equipment).
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-program-districts.md
+++ b/_datasets/ppr-program-districts.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Polygon boundaries of PPR's program districts as established by PPR's GIS\
   \ staff and reviewed, revised, and approved by PPR's executive staff."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-properties.md
+++ b/_datasets/ppr-properties.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Locations and boundaries for properties that Philadelphia Parks and Recreation
   (PPR) has responsibility for or has a distinct role in the maintenance or management.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-spraygrounds.md
+++ b/_datasets/ppr-spraygrounds.md
@@ -8,7 +8,7 @@ maintainer_email: chris.park@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "The location of spraygrounds in Philadelphia run by Parks and Recreation."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-swimming-pools.md
+++ b/_datasets/ppr-swimming-pools.md
@@ -9,7 +9,7 @@ maintainer_email: chris.park@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "The location of swimming pools in Philadelphia run by Parks and Recreation."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-tennis-courts.md
+++ b/_datasets/ppr-tennis-courts.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Displays the locations of tennis courts located within properties maintained
   by Philadelphia Parks and Recreation (PPR).
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-tree-canopy.md
+++ b/_datasets/ppr-tree-canopy.md
@@ -19,7 +19,7 @@ notes: "2018 data: This dataset was developed as part of an Urban Tree Canopy (U
   \ off the 2015 Leaf-Off 3\" AccuPLUS Imagery representing changes in tree canopy\
   \ visible within the imagery. Heights have been derived separately for each tree\
   \ canopy outline from 2015 LiDAR data capture."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/prep-providers.md
+++ b/_datasets/prep-providers.md
@@ -8,7 +8,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: This point layer contains the locations of PrEP providers in the City of Philadelphia.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/professional-services-contracts.md
+++ b/_datasets/professional-services-contracts.md
@@ -20,7 +20,7 @@ notes: "The entire dataset for Professional Services Contracts by fiscal quarter
   \ a breakdown of contract dollars by vendor, department and service type. It also\
   \ features a \u201Cfrequently asked questions\u201D section to help users understand\
   \ the available data: http://cityofphiladelphia.github.io/contracts/.  "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: '***To download:  click on the dataset url, which will open in a new

--- a/_datasets/pssa-keystone-performance.md
+++ b/_datasets/pssa-keystone-performance.md
@@ -18,7 +18,7 @@ notes: "\u2022 Actual Performance files: calculated using actual student perform
   \ up the Keystone end-of-course assessments. Results are reported for All Students,\
   \ and are also broken down by Gender, Ethnicity, English Language Learner (ELL)\
   \ status, Special Education (IEP) status, and Economically Disadvantaged status."
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-customer-service-calls.md
+++ b/_datasets/pwd-customer-service-calls.md
@@ -12,7 +12,7 @@ notes: "Every call received by the Customer Information Unit for issues like ope
   \ hydrants, cave ins, and more. Calls are categorized as to the type of issue at\
   \ hand. Includes outcomes of calls. Billing matters are referred to the Water Revenue\
   \ Bureau."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-geotechnical-tests.md
+++ b/_datasets/pwd-geotechnical-tests.md
@@ -19,7 +19,7 @@ notes: "BACKGROUND - The objective of geotechnical testing is to help determine 
   \ and subsurface lithology results such as depth to bedrock and depth to groundwater\
   \ may be helpful for other users of this layer, but it is important to note that\
   \ these values can vary widely from location to location, even for nearby sites."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-sewersheds.md
+++ b/_datasets/pwd-sewersheds.md
@@ -12,7 +12,7 @@ notes: A sewershed is the area of land where all the sewers flow to a single end
   in most cases it is a regulator/permitted outfall, but in cases when the flow can
   be split between multiple regulators/permitted outfalls, the area above the point
   of split is treated as a separate sewershed.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-stormwater-billing-parcels.md
+++ b/_datasets/pwd-stormwater-billing-parcels.md
@@ -17,7 +17,7 @@ accurate assessment of the impervious area on the parcel, and that there is owne
 associated with the parcel. Over the past 5 years, PWD has made corrections based off deeds
 on file with DOR, BRT information, and other City records. PWD also matched up each DOR parcel
 to a corresponding BRT record that contained the owner information for that parcel."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-stream-sampling-locations.md
+++ b/_datasets/pwd-stream-sampling-locations.md
@@ -13,7 +13,7 @@ notes: "Locations where PWD has conducted surface water quality sampling and oth
   \ types of stream assessments. Sampling activities may include water quality grab\
   \ sampling, habitat assessment, and sampling of invertebrates, fish and algae from\
   \ wadeable streams. Not all assessment activities are performed at all sites."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/railroad-lines.md
+++ b/_datasets/railroad-lines.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "This is one of the planimetric coverages developed as part of the aerial survey\
   \ project of 1996 and updated using new aerial photography collected between 25\
   \ March 2004 and 23 April 2004."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/rain-barrels.md
+++ b/_datasets/rain-barrels.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Rain Barrels installed under PWD's Rain Barrel Workshop and Installation program,\
   \ which ran from 2006 to 2014."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/rain-check-installation-sites.md
+++ b/_datasets/rain-check-installation-sites.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Rain Check is a Philadelphia Water Department program that helps residents\
   \ manage stormwater and beautify their homes."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/rain-gauges.md
+++ b/_datasets/rain-gauges.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "The purpose of this data is to describe the Rain Gauges both locationally\
   \ and via their attributes. This data shows the location and attributes of Rain\
   \ Gauges throughout the City of Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/real-estate-tax-balances.md
+++ b/_datasets/real-estate-tax-balances.md
@@ -10,7 +10,7 @@ maintainer_email: 	roman.strakovsky@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Data about real estate accounts with tax balances. The aggregated datasets include both accounts with overdue balances  (property owner owes a late balance in the current tax year but it is not yet considered delinquent) and tax delinquencies. Tax delinquencies are accounts with outstanding balances for previous tax years. A past due account becomes delinquent when the real estate tax is still unpaid on January 1 of the following year that the tax was due."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 

--- a/_datasets/real-estate-transfers.md
+++ b/_datasets/real-estate-transfers.md
@@ -26,7 +26,7 @@ notes: "The Department of Records (DOR) published data for all documents recorde
   If you are comfortable with APIs, you could also use the API links to access this\
   \ data. You can learn more about how to use the API at [Carto\u2019s SQL API site](https://carto.com/developers/sql-api/)\
   \  and in the [Carto guide in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/recyclebank-participation.md
+++ b/_datasets/recyclebank-participation.md
@@ -8,7 +8,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Please note that the RecyleBank Program no longer exists, therefore this dataset has been archived, and will not be updated, but remains for historical analysis purposes. Dataset shows the count of residents participating in the RecycleBank program by street segment in 2015."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/recycling-diversion-rate.md
+++ b/_datasets/recycling-diversion-rate.md
@@ -12,7 +12,7 @@ notes: "Rate of recycling per rubbish/recycling district in total tons of recycl
   \ divided by the total tons of rubbish (garbage) collected during the given time\
   \ period, either fiscal year, a fiscal year through a given quarter, or within one\
   \ quarter."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/recycling-donations-resources.md
+++ b/_datasets/recycling-donations-resources.md
@@ -9,7 +9,7 @@ maintainer_email: null
 maintainer_link: null
 maintainer_phone: null
 notes: "A dataset of the places to donate or recycle items in Philadelphia."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'An online app to find recylcing and donation resources near the address you enter.'

--- a/_datasets/red-light-cameras.md
+++ b/_datasets/red-light-cameras.md
@@ -10,7 +10,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Locations of red light cameras maintained by the Philadelphia Parking Authority."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/redevelopment-certified-areas.md
+++ b/_datasets/redevelopment-certified-areas.md
@@ -15,7 +15,7 @@ notes: "Development certified areas, i.e. areas deemed blighted and eligible for
   \ Urban Redevelopment Law. Blighted areas are defined as meeting one of seven city\
   \ mandated criteria, including unsafe, unsanitary and inadequate conditions; economically\
   \ or socially undesirable land use; and faulty street and lot layout."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/registered-community-gardens.md
+++ b/_datasets/registered-community-gardens.md
@@ -13,7 +13,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Locations of community gardens throughout the City of Philadelphia that are\
   \ registered with the Philadelphia Parks and Recreation's Urban Agriculture Team."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/registered-community-organizations-rco-boundaries.md
+++ b/_datasets/registered-community-organizations-rco-boundaries.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Boundaries of Registered Community Organizations (RCO) as established under\
   \ the City of Philadelphia Zoning Code enacted December 15, 2011 and made effective\
   \ August 22, 2012.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/residency-waivers.md
+++ b/_datasets/residency-waivers.md
@@ -15,7 +15,7 @@ notes: "The table below shows which job positions have received a waiver from th
   \ Philadelphia within six months after your appointment date.\r\n-Civil service\
   \ positions: you must live in Philadelphia for one year before your appointment\
   \ date."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/residential-parking-permit-blocks.md
+++ b/_datasets/residential-parking-permit-blocks.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
   Discussion Group](http://www.phila.gov/data/discuss/)
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/retrofitted-homes.md
+++ b/_datasets/retrofitted-homes.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
   Discussion Group](http://www.phila.gov/data/discuss/)
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/riparian-buffers.md
+++ b/_datasets/riparian-buffers.md
@@ -18,7 +18,7 @@ notes: 'Areas of stream bank sections (including main stem, tributaries and smal
   Pennsylvania Stream ReLeaf programs. For the followup work in 2012, only three counties
   were completed with Heritage Conservancy performing the work in
   Philadelphia and Bucks counties, and Montgomery County mapped by the county.'
-opendataphilly_rating: '3'
+modified: null
 organization: Heritage Conservancy
 resources:
 - description: ''

--- a/_datasets/ryan-white-hiv-treatment-centers.md
+++ b/_datasets/ryan-white-hiv-treatment-centers.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Street location, contact information and hours of PDPH-funded HIV Treatment\
   \ Centers."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-areas.md
+++ b/_datasets/sanitation-areas.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.phila.gov/streets
 maintainer_phone: 215-686-8287
 notes: "Data includes the boundaries for city sanitation areas (which are aggregations\
   \ of Sanitation Districts)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-collection-day-boundary.md
+++ b/_datasets/sanitation-collection-day-boundary.md
@@ -17,7 +17,7 @@ notes: "The data is used to determine the day of sanitation collection (rubbish 
   \ can tell you if both sides of the arc belong to one of the bounding polygons.\
   \  All the arcs, including those with no boundary info, have naming attributes for\
   \ labeling the polygon borders. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-convenience-centers.md
+++ b/_datasets/sanitation-convenience-centers.md
@@ -9,7 +9,7 @@ maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Sites where residents can drop off household trash and recycling."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-districts.md
+++ b/_datasets/sanitation-districts.md
@@ -10,7 +10,7 @@ maintainer_link: http://www.phila.gov/streets/
 maintainer_phone: 215-686-8287
 notes: "Boundaries of city sanitation districts.  Collection areas are subdivisions\
   \ of districts.  Districts are aggregated up to Sanitation Areas. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/school-finder.md
+++ b/_datasets/school-finder.md
@@ -11,7 +11,7 @@ maintainer_phone: 215-400-4000
 notes: Enter an address to see which school catchment area that address is located
   in. The application can also use the location of the user, retrieved from the user's
   browser, rather than an address. The map is powered by Google Maps.
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: ''

--- a/_datasets/school-information.md
+++ b/_datasets/school-information.md
@@ -9,7 +9,7 @@ maintainer_email: opendata@philasd.org
 maintainer_link: null
 maintainer_phone: null
 notes: School lists, enrollment, demographics, pre-school, catchments; surveys, reopening
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: 2001 - 2021

--- a/_datasets/school-performance.md
+++ b/_datasets/school-performance.md
@@ -12,7 +12,7 @@ notes: School progress report, district scorecard, PSSA & Keystone, district gra
   rate, school graduation rate, aimsweb-star, attendance, out-of-school suspensions,
   serious incidents, NSC student tracker reports, college matriculation, end-of-year
   report
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: SY 2012 - 2019

--- a/_datasets/school-progress-report-data.md
+++ b/_datasets/school-progress-report-data.md
@@ -27,7 +27,7 @@ notes: "Overview:\r\nThe School Progress Report (SPR) is an innovative tool desi
   \ renewal, and expansion\r\n\u2022 To strategically focus resources for greatest\
   \ impact on students\r\n\u2022 To track progress against the Action Plan anchor\
   \ goals"
-opendataphilly_rating: null
+modified: null
 organization: School District of Philadelphia
 resources:
 - description: "As part of our effort to build a System of Great Schools, below is\

--- a/_datasets/schools-parcels.md
+++ b/_datasets/schools-parcels.md
@@ -14,7 +14,7 @@ changing or is not publicly available. If you have specific questions about a sc
 This dataset includes the location of schools in the City of Philadelphia with attribute information for address, 
 grade level, type, and status. The institution types are displayed by default using the following subtypes: 
 district (public schools), charter and private (including archdiocesan). There is also a point layer of [Schools](https://opendataphilly.org/datasets/schools/) available."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/schools.md
+++ b/_datasets/schools.md
@@ -16,7 +16,7 @@ notes: "Data includes points identifying public schools, charter schools, many p
   \ keep in mind that this data, particularly with regards to enrollment, is constantly\
   \ changing or is not publicly available. If you have specific questions about a\
   \ school, please contact that facility directly.__\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/seeclickfix-phila-only.md
+++ b/_datasets/seeclickfix-phila-only.md
@@ -16,7 +16,7 @@ notes: 'An application that enables users to report non-emergency issues in thei
   and leave comments. Reports can be viewed in list, gallery, or map views. An API
   is available. Key based authentication is required and obtained after registering
   for a free account with SeeClickFix. A mobile version is also available. '
-opendataphilly_rating: null
+modified: null
 organization: SeeClickFix
 resources:
 - description: ''

--- a/_datasets/septa-alerts.md
+++ b/_datasets/septa-alerts.md
@@ -17,7 +17,7 @@ notes: 'Provides access to SEPTA travel alerts via an API. All travel alerts can
   <br>
   <br>The API endpoint at get_alert_data.php provides more verbose messages for either the whole system or a single route
   <br>Example: https://www3.septa.org/api/Alerts/get_alert_data.php?route_id=bus_route_33'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: 'can return all alerts in SEPTA system or alerts for a specific route'

--- a/_datasets/septa-bus-detours.md
+++ b/_datasets/septa-bus-detours.md
@@ -15,7 +15,7 @@ notes: 'Provides access to current SEPTA bus detours via an API. All detours for
    <br>
    Example: https://www3.septa.org/api/BusDetours/23
    '
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-dashboards.md
+++ b/_datasets/septa-dashboards.md
@@ -9,7 +9,7 @@ maintainer_email: septoid@gmail.com
 maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: 'Visual dashboards that describe ridership and performance metrics.'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-elevator-outages.md
+++ b/_datasets/septa-elevator-outages.md
@@ -9,7 +9,7 @@ maintainer_email: septoid@gmail.com
 maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: 'Returns a list of all elevator outages. The API does not require any paramters.'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-finances.md
+++ b/_datasets/septa-finances.md
@@ -9,7 +9,7 @@ maintainer_email: septoid@gmail.com
 maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: 'SEPTA financial data including expense by category and vendor and financial projections.'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: 'Contains information on major expense categories, used to observe major trends.'

--- a/_datasets/septa-gtfs-alerts-updates.md
+++ b/_datasets/septa-gtfs-alerts-updates.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: 'SEPTA publishes real-time alerts, updates, and vehicle positions as GTFS-RT 
   data feeds in protocol buffer (protobuf) format. A human-readable version is available 
   from each end-point using /print.php but will only have the most recent 5 records.'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-gtfs.md
+++ b/_datasets/septa-gtfs.md
@@ -10,7 +10,7 @@ maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: 'SEPTA schedule and location information in GTFS format.  Additional informatoion can be found on GitHub
   (https://github.com/septadev/GTFS/) or Google group (https://groups.google.com/forum/#!forum/septadev)'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: 'Each new release is posted on GitHub. Each zip file contains a separate

--- a/_datasets/septa-real-time-map.md
+++ b/_datasets/septa-real-time-map.md
@@ -10,7 +10,7 @@ maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: 'The SEPTA Real-time Map combines the results of several APIs, 
 including bus, trolley and regional rail locations and alerts.'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-regional-rail-trainview.md
+++ b/_datasets/septa-regional-rail-trainview.md
@@ -29,7 +29,7 @@ notes: '
   Please refer to the Regional Rail Inputs page (see below) to see all valid inputs.
 '
 
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: 'Creates a list of all Regional Rail trains on the system. Showing the trains ID number, its starting location, its destination, and if its late or not'

--- a/_datasets/septa-ridership-statistics.md
+++ b/_datasets/septa-ridership-statistics.md
@@ -16,7 +16,7 @@ notes: 'Stop summary files represent average daily ridership at the stop level o
   for Fall 2020 due to a malware attack. APC bus data was also not available for 
   articulated vehicles and the Boulevard Direct from August 2020 through February 2022
   due to the malware attack.'
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-routes-stops-locations.md
+++ b/_datasets/septa-routes-stops-locations.md
@@ -10,7 +10,7 @@ maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: "Geographic data for SEPTA routes, stops, and locations is available from both
   APIs and GIS data."
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: 'A list of bus and trolley stop locations for each route returned in JSON format. A list of route IDs can be found at https://www3.septa.org/VIBusAndTrolley.html and in GTFS files.'

--- a/_datasets/septa-schedules.md
+++ b/_datasets/septa-schedules.md
@@ -21,7 +21,7 @@ notes: 'Provides API access to SEPTA regional rail, bus, and trolley schedules.
   returns scheduled stops for Ridge Av & Walnut Ln
   <br>
   '
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-sms-transit.md
+++ b/_datasets/septa-sms-transit.md
@@ -67,7 +67,7 @@ notes: 'SEPTA SMS Transit enables users to request scheduled trip information vi
 
   </ol>
    '
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/septa-transitview.md
+++ b/_datasets/septa-transitview.md
@@ -13,7 +13,7 @@ notes: 'TransitView provides real-time information about SEPTA buses and trolley
   a route number and retuns locations for all vehicles on that route. <br><br>
 
   Example: https://www3.septa.org/api/TransitView/index.php?route=33 returns all vehicles on bus route 33' 
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: 'returns all bus and trolley locations'

--- a/_datasets/septa-trip-planner.md
+++ b/_datasets/septa-trip-planner.md
@@ -9,7 +9,7 @@ maintainer_email: septoid@gmail.com
 maintainer_link: https://wwww.septa.org/open-data/
 maintainer_phone: null
 notes: 'Trip planner for finding SEPTA routes and times between an origin and destination.' 
-opendataphilly_rating: null
+modified: null
 organization: SEPTA
 resources:
 - description: ''

--- a/_datasets/sharps-drop-boxes.md
+++ b/_datasets/sharps-drop-boxes.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: This point layer contains the locations of sharps (needle) drop boxes in the
   City of Philadelphia.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/shooting-victims.md
+++ b/_datasets/shooting-victims.md
@@ -9,7 +9,7 @@ maintainer_email: publicsafetygis@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "City-wide shooting victims, including Police Officer-involved shootings"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Guided tour of the data, contextualized with other datasets

--- a/_datasets/skookul-septa-real-time-locator.md
+++ b/_datasets/skookul-septa-real-time-locator.md
@@ -14,7 +14,7 @@ notes: 'The SEPTA Real Time Locator on Skookul Philadelphia provides real time a
   accessed via mobile, desktop, and laptop devices. Users can bookmark specific data
   requests such as a bus route (http://skookul.com/transportation/#bus-9) or train
   route (http://skookul.com/transportation/#train-airport).   '
-opendataphilly_rating: '4'
+modified: null
 organization: Skookul.com
 resources:
 - description: ''

--- a/_datasets/snow-emergency-routes.md
+++ b/_datasets/snow-emergency-routes.md
@@ -22,7 +22,7 @@ notes: "From the Streets Department snow emergency route page\r\n\r\nWhen snow a
   \ emergency routes. The snow emergency routes shapefile/geojson is built by filtering\
   \ the street centerline layer to include only those rows where the seg_id is contained\
   \ in this list."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/soil-survey-philadelphia-county.md
+++ b/_datasets/soil-survey-philadelphia-county.md
@@ -16,7 +16,7 @@ notes: "A digital soil survey and generally is the most detailed level of soil
   use and management. The soil map units are linked to attributes in the National Soil Information System
   relational database, which gives the proportionate extent of the component soils and their properties."
 
-opendataphilly_rating: null
+modified: null
 organization: Natural Resources Conservation Service
 resources:
 - description: ''

--- a/_datasets/special-vending-districts.md
+++ b/_datasets/special-vending-districts.md
@@ -15,7 +15,7 @@ maintainer_phone: null
 notes: "Districts with special sidewalk vending rules pursuant to Sections 9-204 (Sidewalk\
   \ Vendors in Center City) and 9-206 (Sidewalk Vendors in Neighborhood Business Districts)\
   \ of The Philadelphia Code.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/speculative-monuments-for-philadelphia.md
+++ b/_datasets/speculative-monuments-for-philadelphia.md
@@ -12,7 +12,7 @@ notes: "This data describes proposals for future monuments collected from Philad
   residents and visitors to during Monument Lab events in May 2015 and Autumn 2017. Each proposal was transcribed
   and analyzed by the Monument Lab team, and is identified with the location of the
   proposed monument. In May 2015, 450 proposals were collected from residents and visitors during a three week exhibition in the City Hall courtyard. In Autumn 2017, 4,500 proposals were collected from residents and visitors during a citywide exhibition held at 10 sites. Each proposal is identified by the location of the proposed monutment and include age and zip code of the proposer."
-opendataphilly_rating: null
+modified: null
 organization: Monument Lab
 resources:
 - description: ''

--- a/_datasets/storefront-improvement-program-grants-disbursed.md
+++ b/_datasets/storefront-improvement-program-grants-disbursed.md
@@ -13,7 +13,7 @@ notes: "This data set reflects the recipients, award amounts, and project sites 
   \ grant money disbursed by the Philadelphia Commerce Department for the Storefront\
   \ Improvement Program whereby businesses are provided the funds to improve the exterior\
   \ of their storefront.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/stormwater-management-practice-polygons.md
+++ b/_datasets/stormwater-management-practice-polygons.md
@@ -12,7 +12,7 @@ notes: "This layer represents Green Stormwater Infrastructure Stormwater Managem
   \ Practice types. Integrating Green Stormwater Infrastructure (GSI) into a highly\
   \ developed area such as Philadelphia requires a decentralized and creative approach\
   \ to planning and design.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/stormwater-outfalls.md
+++ b/_datasets/stormwater-outfalls.md
@@ -11,7 +11,7 @@ notes: "This point layer contains all the stormwater outfalls. The Purpose of th
   \ data is to describe the asset both locationally and via its attributes which are\
   \ extensive for a GIS dataset and which are maintained. This data will serve as\
   \ a platform for planning, analysis and research at PWD.\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-centerlines-for-vision-zero-high-injury-network-2017.md
+++ b/_datasets/street-centerlines-for-vision-zero-high-injury-network-2017.md
@@ -13,7 +13,7 @@ notes: "This dataset contains a modified version of street centerlines used for 
   \ analysis to derive the High Injury Network (HIN). This version has been arrived\
   \ at, using steps described in the methodology for High Injury Network. See the\
   \ Metadata link for an attached PDF describing the methodology.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-centerlines.md
+++ b/_datasets/street-centerlines.md
@@ -14,7 +14,7 @@ notes: "Used citywide as base layer for many purposes/applications. The street c
   \ specifiactions. The Philadelphia Streets Department makes no guarantees as to\
   \ the accuracy of the layer. Associated tables can be found here: https://www.opendataphilly.org/datasets/street-place-names\
   \  \r\nhttps://www.opendataphilly.org/datasets/street-name-alias-list "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-lane-closure-emergency-utility-network.md
+++ b/_datasets/street-lane-closure-emergency-utility-network.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This layer shows the Philadelphia Gas Works (PGW) Emergency Utility Network\
   \ (EUN) with Excavation points.  "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-lane-closures-pgw.md
+++ b/_datasets/street-lane-closures-pgw.md
@@ -15,7 +15,7 @@ notes: "This is an API for querying street lane closures made by PGW for mainten
   \ closures.  Both methods return data for the Project Number, Address, EUN Number,\
   \ Construction Start/End date, reason for the work, degree of closure, and contact\
   \ information for the responsible party at PGW.\r\n"
-opendataphilly_rating: null
+modified: null
 organization: Philadelphia Gas Works
 resources:
 - description: ''

--- a/_datasets/street-lane-closures.md
+++ b/_datasets/street-lane-closures.md
@@ -11,7 +11,7 @@ notes: "Street lane closures for general public use. This is the master layer de
   \ the Lane Closures due to permitted road work. This layer shows the type and purpose\
   \ of working being done, the effective dates of the permits issued, as well the\
   \ status of the work.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-legal-cards.md
+++ b/_datasets/street-legal-cards.md
@@ -16,7 +16,7 @@ maintainer_phone: null
 notes: "Street Centerline Arcs with link to legal cards, which are a collection of\
   \ cards containing the official record of the legal description and drawings of\
   \ city streets."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-name-alias-list.md
+++ b/_datasets/street-name-alias-list.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Table to display street names which have aliased street names associated with\
   \ them."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-nodes.md
+++ b/_datasets/street-nodes.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "The street nodes layer was developed for use by agencies citywide including\
   \ PWD, PCPC, Police, BRT, Health, etc. \r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-place-names.md
+++ b/_datasets/street-place-names.md
@@ -12,7 +12,7 @@ maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "A listing of \"places\" and their corresponding addresses to be used for geocoding."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/street-poles.md
+++ b/_datasets/street-poles.md
@@ -14,7 +14,7 @@ notes: "This layer was developed to aid the Street Lighting Division in planning
   \ referencing, and maintaining the active street poles within the City of Philadelphia.\
   \  Examples include: providing information regarding group replacement projects\
   \ and any individual edits, using tables from layer for billing, and aiding cityworks."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-smart-phl.md
+++ b/_datasets/street-smart-phl.md
@@ -10,7 +10,7 @@ maintainer_link: https://www.phila.gov/departments/department-of-streets/
 maintainer_phone: 215-686-5560
 notes: "This interactive mapping application displays current/future street closures, trash/recycling days, street sweeping plans,
 snow plowing info (during a snow event) and paving plans."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/streets-code-violation-notices.md
+++ b/_datasets/streets-code-violation-notices.md
@@ -22,7 +22,7 @@ notes: "A code violation notice is issued from the Street's department when a pe
   \ also use the API links to access this data. You can learn more about how to use\
   \ the API at Carto\u2019s SQL API site and in the Carto guide in the section on\
   \ making calls to the API.**"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/streets-composite-layer.md
+++ b/_datasets/streets-composite-layer.md
@@ -13,7 +13,7 @@ notes: The composite layer is an arc layer, consisting of street centerline arcs
   a layer used by many departments to create boundaries. Used for viewing and analysis
   puposes. The composite layer is available for reference purposes only and does not
   represent exact engineering specifications.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/taking-care-of-business.md
+++ b/_datasets/taking-care-of-business.md
@@ -14,7 +14,7 @@ notes: 'Philadelphia Taking Care of Business (PHL TCB) Clean Corridors Program f
   PHL TCB seeks to 1-Maintain clean commercial districts, 2-Promote the economic success of neighborhood businesses by
   creating an inviting environment for shoppers, 3-Create work opportunities for Philadelphians, 4-Grow
   the capacity of local small businesses and organizations that provide cleaning services.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/tobacco-free-school-zones.md
+++ b/_datasets/tobacco-free-school-zones.md
@@ -13,7 +13,7 @@ notes: "Tobacco-free school zones included in the tobacco retailing regulations.
   \ of any K-12 school property parcel. [For more information visit](http://www.phila.gov/health/Commissioner/regulationtobaccoretailing.html)\r\
   \n\r\nRelated datasets include the [Tobacco Retailers Permits](https://www.opendataphilly.org/datasets/tobacco-retailer-permits)\
   \ and [Tobacco Youth Sales Violations](https://www.opendataphilly.org/datasets/tobacco-youth-sales-violations)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/tobacco-retailer-density-caps.md
+++ b/_datasets/tobacco-retailer-density-caps.md
@@ -15,7 +15,7 @@ notes: "Tobacco Retailer Density Caps for each planning district included in the
   \ estimates. For more information visit: [Tobacco Retailing](http://www.phila.gov/health/Commissioner/regulationtobaccoretailing.html).\r\
   \n\r\nVisit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\
   \n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/tobacco-retailer-permits.md
+++ b/_datasets/tobacco-retailer-permits.md
@@ -13,7 +13,7 @@ notes: "Retailers apply for a tobacco permit through an online application syste
   \ cleaned and stored in a database maintained by the Department of Public Health.\r\
   \n\r\nRelated datasets include the [Tobacco Youth Sales Violations](https://www.opendataphilly.org/datasets/tobacco-youth-sales-violations)\
   \ and [Tobacco-Free School Zones](https://www.opendataphilly.org/datasets/tobacco-free-school-zones)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/topographic-change-in-philadelphia.md
+++ b/_datasets/topographic-change-in-philadelphia.md
@@ -26,7 +26,7 @@ of uncertainties. The following report is in fulfillment of the tasks outlined i
 this scope of work and was performed by the U. S. Geological Survey for the U. S.
 Army Corps of Engineers, Philadelphia District under MIPR agreement number: W25PHS93358288.'
 
-opendataphilly_rating: null
+modified: null
 organization: US Geological Survey
 resources:
 - description: ''

--- a/_datasets/topographic-contours.md
+++ b/_datasets/topographic-contours.md
@@ -13,7 +13,7 @@ notes: "This dataset is a contour data line segments representing the elevation 
   \ Data is typically collected during the month of April. Data Development: Vector\
   \ (line) data representing the elevation of natural and artificial features in the\
   \ project area."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/tornadoes-1950-2004.md
+++ b/_datasets/tornadoes-1950-2004.md
@@ -13,7 +13,7 @@ notes: 'Data includes location touchdown points and corresponding dates of Torna
   in Pennsylvania from 1950 to 2004, according to the National Weather Service''s
   Storm Prediction Center (SPC). Data originates from the Severe Thunderstorm Database
   and the National Oceanic and Atmosphere Administration Storm Data publication. '
-opendataphilly_rating: null
+modified: null
 organization: Storm Prediction Center
 resources:
 - description: ''

--- a/_datasets/track-streets.md
+++ b/_datasets/track-streets.md
@@ -9,7 +9,7 @@ maintainer_email: michael.matela@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Street segments containing train tracks."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/traffic-calming.md
+++ b/_datasets/traffic-calming.md
@@ -7,7 +7,7 @@ maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 maintainer_link: http://www.phila.gov/streets/
 notes: "Point-based dataset showing the approximate locations where Traffic Calming Devices exist in the street to reduce speeding of motor vehicles. Traffic Calming Devices examples are speed cushions, speed humps, and speed tables. These devices could be made of asphalt or rubber materials."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/traffic-districts.md
+++ b/_datasets/traffic-districts.md
@@ -12,7 +12,7 @@ notes: "This layer was developed to aid the Traffic Division in planning, organi
   \ and maintaining traffic flow within the City of Philadelphia.  Examples include:\
   \  the maintenance and placing of stop signs and signals and monitoring street travel\
   \ direction. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/traffic-preventative-maintenance-districts.md
+++ b/_datasets/traffic-preventative-maintenance-districts.md
@@ -21,7 +21,7 @@ notes: "This layer was developed to aid the Traffic Division in planning, organi
   \ labeling the polygon borders.  Contact the Streets GIS unit for public consumption\
   \ of the corresponding arc layer.\r\
   \n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/urban-agriculture-projects.md
+++ b/_datasets/urban-agriculture-projects.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Urban agriculture projects located within Philadelphia Parks and Recreation\
   \ sites."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/us-congressional-districts.md
+++ b/_datasets/us-congressional-districts.md
@@ -9,7 +9,7 @@ maintainer_email: ''
 maintainer_link: null
 maintainer_phone: null
 notes: "Please refer to PA's open data for the [United States Congressional Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-Congressional-District-Boundaries/3b9u-tn7c)."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources: []
 schema: philadelphia

--- a/_datasets/vacant-lot-cleanups.md
+++ b/_datasets/vacant-lot-cleanups.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Dates and locations of when lots were cleaned (removing weeds, debris, etc.)\
   \ through the City of Philadelphia's Community Life Improvement Program."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vacant-property-indicators-percentage-by-block.md
+++ b/_datasets/vacant-property-indicators-percentage-by-block.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Block by block percentages across Philadelphia showing the percentages of\
   \ properties (buildings and lots) in each block considered likely to be vacant by\
   \ the city's Vacant Property Indicators Model."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vacant-property-indicators.md
+++ b/_datasets/vacant-property-indicators.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "The location of properties across Philadelphia that are likely to be a vacant\
   \ lot or vacant building based on an assessment of City of Philadelphia administrative\
   \ datasets."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vehicle-pedestrian-investigations.md
+++ b/_datasets/vehicle-pedestrian-investigations.md
@@ -19,7 +19,7 @@ notes: "Police investigations of pedestrians and vehicles from the Philadelphia 
   \ years to see the full dataset. You can learn more about how to use the API at\
   \ [Carto\u2019s SQL API site](https://carto.com/developers/sql-api/) and in the\
   \ [Carto guide in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Guided tour of the data, contextualized with other datasets

--- a/_datasets/vending-prohibited-areas.md
+++ b/_datasets/vending-prohibited-areas.md
@@ -12,7 +12,7 @@ maintainer_email: ligisteam@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Areas where vending is prohibited in the city of Philadelphia.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vending-prohibited-streets.md
+++ b/_datasets/vending-prohibited-streets.md
@@ -15,7 +15,7 @@ notes: Streets where vending is prohibited.  Used citywide as base layer for man
   purposes/applications. The street centerline is available for reference purposes
   only and does not represent exact engineering specifications. The Philadelphia Streets
   Department makes no guarantees as to the accuracy of the layer.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vending-prohibition-exceptions.md
+++ b/_datasets/vending-prohibition-exceptions.md
@@ -12,7 +12,7 @@ maintainer_email: ligisteam@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: A layer providing exceptions to the vending prohibition streets layer as indicated by the City of Philadelphia's legislative process. Features represent streets or intersections whereby the City has made exceptions to certain or all vending restrictions. Specific exception parameters are summarized in the "REMARKS" column and can be found in full detail by accessing specific sections/subsections of the Philadelphia Code.
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vision-zero-high-injury-network.md
+++ b/_datasets/vision-zero-high-injury-network.md
@@ -13,7 +13,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This data contains the High Injury Network. It is derived using spatial data\
   \ analysis of crash data for years 2012-2016 from Pennsylvania Department of Transportation."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: Vision Zero dashboard on reducing traffic deaths. 

--- a/_datasets/voter-turnout.md
+++ b/_datasets/voter-turnout.md
@@ -10,7 +10,7 @@ maintainer_phone: null
 notes: "The current dataset captures voter registration counts and voter 'turnout', or the percentage of registered voters who voted in each election, since 2015.
   The data is aggregated at various levels including the political precinct (division), political ward, and city-wide and shows results for different elections (primary, general,
   special). Historical releases of this data prior to 2015 were separate datasets, one for voter turnout and one for voter registration."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: 'This data is aggregated city-wide from 2015 to the current available year.'

--- a/_datasets/walk-score-phila-only.md
+++ b/_datasets/walk-score-phila-only.md
@@ -20,7 +20,7 @@ notes: 'An online application, which enables users to view calculated walkabilit
   which measure the convenience/proximity to bikability and public transit opportunities.
   Users can also access walking, biking, and transit score through an API.  More information
   about the Walk Score is available [through Redfin](https://www.redfin.com/how-walk-score-works). '
-opendataphilly_rating: null
+modified: null
 organization: Walk Score
 resources:
 - description: ''

--- a/_datasets/water-department-grants-disbursed.md
+++ b/_datasets/water-department-grants-disbursed.md
@@ -17,7 +17,7 @@ notes: "Collection Process:  This data set reflects the recipients, award amount
   \ be useful to community organizations interested in serving as stewards of green\
   \ infrastructure located in their area. And it can be useful to businesses impacted\
   \ by PWD projects.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/water-inlets.md
+++ b/_datasets/water-inlets.md
@@ -10,7 +10,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "This point layer contains all the wastewater and stormwater inlets in Philadelphia\
   \ with latitude and longitude coordinates. \r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/watercourses-designated-for-protection.md
+++ b/_datasets/watercourses-designated-for-protection.md
@@ -14,7 +14,7 @@ notes: "Hydrographic features included in Philadelphia Hydrology Map. This map w
   \ watercourses within Philadelphia County as they appear on the map and will not\
   \ be edited or updated. For up-to-date hydrography see the Hydrolographic_Features_Poly\
   \ layer under Hydrology.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/west-philadelphia-promise-zone.md
+++ b/_datasets/west-philadelphia-promise-zone.md
@@ -12,7 +12,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Area designated by the U.S. Department of Housing and Urban Development deeming\
   \ West Philadelphia as a Promise Zone. Click here to learn more about promise zones."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/weworkinphilly.md
+++ b/_datasets/weworkinphilly.md
@@ -13,7 +13,7 @@ notes: WeWorkInPhilly is a community-edited guide to the People, Companies, Grou
   Projects, Products, and Resources that make up the creative, technology, and business
   community in Philadelphia.  The project, launched in July 2011 as a joint effort
   across the local tech community, is "owned by none and supported by all."
-opendataphilly_rating: null
+modified: null
 organization: WeWorkInPhilly
 resources:
 - description: ''

--- a/_datasets/wire-waste-baskets-trash-bins.md
+++ b/_datasets/wire-waste-baskets-trash-bins.md
@@ -9,7 +9,7 @@ maintainer_email: max.steinbrenner@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Non Big Belly waste baskets maintained/collected by the City of Philadelphia.\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/women-infants-children-wic-offices.md
+++ b/_datasets/women-infants-children-wic-offices.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "The Special Supplemental Nutrition Program for Women, Infants, and Children\
   \ (WIC) ."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-authorized-vehicle-route.md
+++ b/_datasets/world-meeting-of-families-authorized-vehicle-route.md
@@ -14,7 +14,7 @@ notes: "This layer highlights the authorized vehicle routes for the 2015 World M
   \ and other mission critical traffic. Regular traffic will not be permitted on the\
   \ routes. Check for updates frequently as information is subject to change. For\
   \ a more detailed description of the event and operations: http://www.phila.gov/informationcenters/pope/."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-secure-perimeter.md
+++ b/_datasets/world-meeting-of-families-secure-perimeter.md
@@ -10,7 +10,7 @@ maintainer_email: oem@phila.gov
 maintainer_link: null
 maintainer_phone: null
 notes: "Secure perimeter for the 2015 World Meeting of Families in Philadelphia, PA."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-secure-vehicle-perimeter.md
+++ b/_datasets/world-meeting-of-families-secure-vehicle-perimeter.md
@@ -11,7 +11,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Secure vehicle perimeter for the 2015 World Meeting of Families in Philadelphia,\
   \ PA."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-traffic-box.md
+++ b/_datasets/world-meeting-of-families-traffic-box.md
@@ -12,7 +12,7 @@ maintainer_phone: null
 notes: "Traffic box for the 2015 World Meeting of Families in Philadelphia, PA.  The\
   \ boundaries and bordering streets were released during a press conference at City\
   \ Hall on August 5th, 2015.\r\n\r\n"
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zillow-phila-only.md
+++ b/_datasets/zillow-phila-only.md
@@ -14,7 +14,7 @@ notes: 'Searchable online database of homes for sale, rent, and not currently on
   specifications, pricing, and keyword. Registration allows for favorite listing saving,
   customized property e-mail alerts, and other privileges. Users can also access real-estate
   listing data through an API. '
-opendataphilly_rating: null
+modified: null
 organization: Zillow
 resources:
 - description: ''

--- a/_datasets/zip-codes.md
+++ b/_datasets/zip-codes.md
@@ -10,7 +10,7 @@ maintainer_phone: 215-686-8287
 notes: "The purpose of this dataset is to represent the Zip Code areas for the City\
   \ of Philadelphia.  The edges of Zip Codes are slightly modified for logical and\
   \ cartographic purposes.\r\n\r\n"
-opendataphilly_rating: '4'
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zoning-base-districts.md
+++ b/_datasets/zoning-base-districts.md
@@ -13,7 +13,7 @@ notes: 'Polygon boundaries of Zoning Base Districts based on existing City zonin
   districts with revised codes applied per enactment of the new Zoning Code of December\
   2011, made effective August 22, 2012. District boundaries are unchanged from the previous\
   zoning with the exception of certain CMX2 / CMX2.5 splits.'
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zoning-overlays.md
+++ b/_datasets/zoning-overlays.md
@@ -9,7 +9,7 @@ maintainer_link: null
 maintainer_phone: null
 notes: "Boundaries of the City of Philadelphia Zoning Overlay Districts enacted December\
   \ 15, 2011 and made effective August 22, 2012."
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zoning-steep-slope-protected-area.md
+++ b/_datasets/zoning-steep-slope-protected-area.md
@@ -11,7 +11,7 @@ maintainer_phone: null
 notes: "Boundaries of the City's Steep Slope Overlay district enacted under Section\
   \ 14-704(2) of the Zoning Code of December 2011 and made effective August 22, 2012.\
   \ See code for further details. "
-opendataphilly_rating: null
+modified: null
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_includes/display/date.html
+++ b/_includes/display/date.html
@@ -1,5 +1,27 @@
 <tr>
     <th>{{ include.field.label }}</th>
     <td>
-      {{ include.value | date: "%B %e, %Y" }}
+      {%- if include.value contains "R/P" -%}
+        {%- case include.value -%}
+          {%- when "R/P1D" -%}
+            Updated daily
+          {%- when "R/P1W" -%}
+            Updated weekly
+          {%- when "R/P1M" -%}
+            Updated monthly
+          {%- when "R/P1Q" -%}
+            Updated quarterly
+          {%- when "R/P1Y" -%}
+            Updated annually
+          {%- else -%}
+            {{ include.value }}
+        {%- endcase -%}
+      {%- else -%}
+        {%- assign date_parts = include.value | split: "-" -%}
+        {%- if date_parts.size >= 3 -%}
+          {{ include.value | date: "%B %e, %Y" }}
+        {%- else -%}
+          {{ include.value }}
+        {%- endif -%}
+      {%- endif -%}
     </td>

--- a/data.json
+++ b/data.json
@@ -34,6 +34,9 @@
     {% assign f_contact_point_email = dataset_fields | where: "datajson", "contactPoint.hasEmail" | first %}
     {% assign contact_point_email = dataset[f_contact_point_email[field_name]] %}
 
+    {% assign f_modified = dataset_fields | where: "datajson", "modified" | first %}
+    {% assign modified = dataset[f_modified[field_name]] %}
+
     {% assign f_dist_title = resource_fields | where: "datajson", "distribution.title" | first %}
     {% assign f_dist_download_url = resource_fields | where: "datajson", "distribution.downloadURL" | first %}
     {% assign f_dist_format = resource_fields | where: "datajson", "distribution.format" | first %}
@@ -72,6 +75,7 @@
       {%- if description -%}
       "description": {{ description | jsonify }},
       {% endif %}
+      "modified": {{ modified | jsonify }},
       "keyword":[
          {%- for cat in dataset.categories -%}
             {%- assign cat_split = cat | split: " / " -%} 


### PR DESCRIPTION
Replaced 'opendataphilly-rating' with 'modified' in the philadelphia.yml schema (we have no mechanism to use the rating field and it's left over from an unused feature in CKAN); changed date rendered to support ISO 8801 standard for data that is updated on a recurring basis; replaced 'opendataphilly-rating' with 'modified' in all data sets; added 'R/P1D' on several files that are updated daily.

Related to 
#89
#264 
#419 