### PR TITLE
Update data.json - add additional URL encode characters

### DIFF
--- a/data.json
+++ b/data.json
@@ -179,6 +179,9 @@
          {
             {%- assign dist_download_url = dist_download_url | replace: " ", "%20" -%}
             {%- assign dist_download_url = dist_download_url | replace: "|", "%7C" -%}
+            {%- assign dist_download_url = dist_download_url | replace: "*", "%2A" -%}
+            {%- assign dist_download_url = dist_download_url | replace: "<", "%3C" -%}
+            {%- assign dist_download_url = dist_download_url | replace: ">", "%3E" -%}
             "title": {{ dist_title | jsonify }},
             {%- if access_flag %}
             "accessURL": {{ dist_download_url | jsonify }},


### PR DESCRIPTION
escaping just the spaces and pipes was not enough and we're still getting URL encode errors with DCAT validation on about a dozen data sets, so I'm adding a few more while sticking with @lydiascarf simpler approach.