### PR TITLE
Update lead-paint-certs.md

### DIFF
--- a/_datasets/lead-paint-certs.md
+++ b/_datasets/lead-paint-certs.md
@@ -2,6 +2,7 @@
 area_of_interest: null
 category:
 - Health / Human Services
+- Environment
 license: City of Philadelphia License
 maintainer: ''
 maintainer_email: ''


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog