### PR TITLE
Update heat-vulnerability-by-census-tract.md

### DIFF
--- a/_datasets/heat-vulnerability-by-census-tract.md
+++ b/_datasets/heat-vulnerability-by-census-tract.md
@@ -3,7 +3,6 @@ area_of_interest: null
 category:
 - Health / Human Services
 - Environment
-created: '2022-07-21T14:36:42.564606'
 license: City of Philadelphia License
 maintainer: Alexandra Skula
 maintainer_email: alexandra.skula@phila.gov
@@ -17,15 +16,15 @@ resources:
 - description: By Census Tracy (CT)
   format: CSV
   name: Heat Vulnerability by CT  (CSV)
-  url: https://opendata.arcgis.com/api/v3/datasets/6afc1177d0cc49dc8c731532b95ccd1f_0/downloads/data?format=csv&spatialRefId=4326&where=1%3D1
+  url: https://hub.arcgis.com/api/v3/datasets/6afc1177d0cc49dc8c731532b95ccd1f_0/downloads/data?format=csv&spatialRefId=2272&where=1%3D1
 - description: By Census Tracy (CT)
   format: SHP
   name: Heat Vulnerability by CT  (SHP)
-  url: https://opendata.arcgis.com/api/v3/datasets/6afc1177d0cc49dc8c731532b95ccd1f_0/downloads/data?format=shp&spatialRefId=4326&where=1%3D1
+  url: https://hub.arcgis.com/api/v3/datasets/6afc1177d0cc49dc8c731532b95ccd1f_0/downloads/data?format=shp&spatialRefId=2272&where=1%3D1
 - description: By Census Tracy (CT)
   format: GeoJSON
   name: Heat Vulnerability by CT (GeoJSON)
-  url: https://opendata.arcgis.com/api/v3/datasets/6afc1177d0cc49dc8c731532b95ccd1f_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
+  url: https://hub.arcgis.com/api/v3/datasets/6afc1177d0cc49dc8c731532b95ccd1f_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1
 - description: By Census Tracy (CT)
   format: API
   name: Heat Vulnerability by CT (API)


### PR DESCRIPTION
ESRI ended redirect for their old link structure; pulling updated links from the City's metadata catalog