### PR TITLE
Fix DCAT validator

### DIFF
--- a/.github/workflows/dcat.yml
+++ b/.github/workflows/dcat.yml
@@ -52,4 +52,4 @@ jobs:
         run: |
           source .venv/bin/activate
           python validate.py  ../_site/data.json
-          cat ./validation-results.json
+          cat ./invalid_datasets.json

--- a/.github/workflows/dcat.yml
+++ b/.github/workflows/dcat.yml
@@ -9,8 +9,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout the current repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
         with:
@@ -29,23 +28,27 @@ jobs:
           PAGES_REPO_NWO: ${{ github.repository }}
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          node-version: 20
-          cache: 'npm'
+          version: "0.11.2"
 
       - name: Clone DCATUS-Validator repository
-        run: |
-          git clone https://github.com/nasa/DCATUS-Validator.git
-          npm --prefix ./DCATUS-Validator install
+        run: git clone https://github.com/nasa/DCATUS-Validator.git
+
+      - name: Install packages with uv
+        working-directory: ./DCATUS-Validator
+        run: uv sync
 
       - name: Modify DCATUS-Validator schema
         run: |
           mv .github/dcat-workflow-non-federal-schema.json ./DCATUS-Validator/schemas/gsa-dcat.json
 
       - name: Run dcat-validator
+        working-directory: ./DCATUS-Validator
         run: |
-          cd ./DCATUS-Validator
-          node dcat-validator.js ../_site/data.json
+          python validate.py  ../_site/data.json
           cat ./validation-results.json

--- a/.github/workflows/dcat.yml
+++ b/.github/workflows/dcat.yml
@@ -50,5 +50,6 @@ jobs:
       - name: Run dcat-validator
         working-directory: ./DCATUS-Validator
         run: |
+          source .venv/bin/activate
           python validate.py  ../_site/data.json
           cat ./validation-results.json

--- a/.github/workflows/dcat.yml
+++ b/.github/workflows/dcat.yml
@@ -52,4 +52,9 @@ jobs:
         run: |
           source .venv/bin/activate
           python validate.py  ../_site/data.json
-          cat ./invalid_datasets.json
+          if [ -f "./invalid_datasets.json" ]; then
+              cat ./invalid_datasets.json
+              exit 1
+          else
+              exit 0
+          fi

--- a/cspell.json
+++ b/cspell.json
@@ -10,8 +10,11 @@
         "Azavea",
         "Geekadelphia",
         "Cheetham",
+        "dcat",
+        "DCATUS",
         "jkan",
         "esac",
+        "venv",
         "jsonify",
         "markdownify",
         "Wisniewski",
@@ -22,6 +25,6 @@
         "ublabs",
         "customised",
         "customise",
-	"shfmt"
+        "shfmt"
     ]
 }


### PR DESCRIPTION
The NASA DCAT validator used to be a Node script, but now it's a Python script. It's now failing because we have validation errors instead of the validator failing to run!

Sorry it took me so long to look into this!