### PR TITLE
ODP data storage repo name change

### DIFF
--- a/_datasets/historic-philadelphia-zoning.md
+++ b/_datasets/historic-philadelphia-zoning.md
@@ -9,28 +9,28 @@ maintainer: Robert Cheetham
 maintainer_email: 'info@opendataphilly.org'
 maintainer_link: null
 maintainer_phone: null
+metadata_modified: '2026-05-09'
+modified: '2024-05-03'
 notes: 'The City of Philadelphia made a major revision of the zoning code and base maps in 2012. 
   These shapefiles provide a few historic versions of zoning data up to the time of the zoning code change.'
-metadata_modified: null
-modified: null
 organization: OpenDataPhilly
 resources:
 - description: ''
   format: SHP
   name: Historic Zoning Base Map 2001
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-zoning/zoning-base-philadelphia-2001-10.zip
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-zoning/zoning-base-philadelphia-2001-10.zip
 - description: ''
   format: SHP
   name: Historic Zoning Base Map 2009
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-zoning/zoning-base-philadelphia-2009-12.zip
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-zoning/zoning-base-philadelphia-2009-12.zip
 - description: ''
   format: SHP
   name: Historic Zoning Base Map 2012
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-zoning/zoning-base-philadelphia-2012-08.zip
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-zoning/zoning-base-philadelphia-2012-08.zip
 - description: ''
   format: SHP
   name: Historic Zoning Overlay Districts 2012
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-zoning/zoning-overlay-philadelphia-2012-08.zip
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-zoning/zoning-overlay-philadelphia-2012-08.zip
 schema: philadelphia
 source: 'OpenDataPhilly'
 tags:

--- a/_datasets/historic-political-wards-divisions.md
+++ b/_datasets/historic-political-wards-divisions.md
@@ -2,12 +2,15 @@
 area_of_interest: null
 category:
 - Elections / Politics
+- Boundaries
 created: '2016-07-27'
 license: License Not Specified
 maintainer: Robert Cheetham
 maintainer_email: 'info@opendataphilly.org'
 maintainer_link: null
 maintainer_phone: null
+metadata_modified: '2026-05-09'
+modified: '2024-06-25'
 notes: 'Election results are published at the Ward and Ward-Division levels.
   However, wards and ward divisions are adjusted on an ongoing bsais, and in order to
   map historic election results, it is necessary to have ward divisions that match
@@ -16,18 +19,16 @@ notes: 'Election results are published at the Ward and Ward-Division levels.
   In addition, some results from open records requests to teh City of Philadelphia.
   Data has been collected for 2003 to 2020.
   Attribute tables were modified to match across all years.'
-metadata_modified: null
-modified: null
 organization: OpenDataPhilly
 resources:
 - description: ''
   format: SHP
   name: Historic Political Wards and Ward Divisions Shapefiles
-  url: https://github.com/azavea/geo-data/tree/master/philadelphia-wards-divisions
+  url: https://github.com/opendataphilly/odp-data-storage/tree/master/philadelphia-wards-divisions
 schema: philadelphia
 source: 'City of Philadelphia'
 tags:
-- divisions
+- election divisions
 - historic
 - political
 - ward

--- a/_datasets/pennypack-park-trail-map.md
+++ b/_datasets/pennypack-park-trail-map.md
@@ -9,27 +9,27 @@ maintainer: ''
 maintainer_email: info@opendataphilly.org
 maintainer_link: null
 maintainer_phone: null
+metadata_modified: '2026-05-09'
+modified: '2025-12-25'
 notes: "This is a map of trails in Pennypack Park, Lorimer Park and Pennypack Trust\
   \ located in Northeast Philadelphia and Montgomery County, PA. Trails were identified\
   \ and collected using common GPS watches (Garmin, Polar, etc) GPX data and verifying\
   \ trails visually using high res aerial imagery to accurately adjust to trails.\r\
   \n"
-metadata_modified: null
-modified: null
 organization: Volunteer
 resources:
 - description: ''
   format: SHP
   name: Pennypack Park Trails Map shapefile
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/pennypack-trails/pennypack-trails.zip
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/pennypack-trails/pennypack-trails.zip
 - description: ''
   format: GeoJSON
   name: Pennypack Park Trails Map GeoJSON
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/pennypack-trails/pennypack-trails.geojson
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/pennypack-trails/pennypack-trails.geojson
 - description: ''
   format: GeoParquet
   name: Pennypack Park Trails Web GeoParquet
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/pennypack-trails/pennypack-trails.parquet
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/pennypack-trails/pennypack-trails.parquet
 schema: philadelphia
 source: ''
 tags:

--- a/_datasets/pennypack-park-trail-map.md
+++ b/_datasets/pennypack-park-trail-map.md
@@ -3,7 +3,7 @@ area_of_interest: null
 category: 
 - Parks / Recreation
 - Environment
-created: '2016-12-01T22:09:27.452175'
+created: '2016-12-01'
 license: License Not Specified
 maintainer: ''
 maintainer_email: info@opendataphilly.org

--- a/_datasets/philadelphia-neighborhoods.md
+++ b/_datasets/philadelphia-neighborhoods.md
@@ -9,29 +9,29 @@ maintainer: 'Robert Cheetham'
 maintainer_email: info@opendataphilly.org
 maintainer_link: null
 maintainer_phone: null
+metadata_modified: '2026-05-09'
+modified: '2024-04-24'
 notes: 'This dataset includes neighborhood boundaries for 150+ neighborhoods in Philadelphia.
   The data was gathered from a mix of publicly available maps, including from the City of Philadelphia,
   the City Archives, the Philadelphia Inquirer, and user feedback.'
-metadata_modified: null
-modified: null
 organization: OpenDataPhilly
 resources:
 - description: ''
   format: SHP
   name: Philadelphia Neighborhoods Shapefile
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.zip
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.zip
 - description: ''
   format: GeoJSON
   name: Philadelphia Neighborhoods GeoJSON
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.geojson
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.geojson
 - description: ''
   format: GeoJSON
   name: Philadelphia Neighborhoods GeoPackage
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.gpkg
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.gpkg
 - description: ''
   format: GeoParquet
   name: Philadelphia Neighborhoods GeoParquet
-  url: https://github.com/opendataphilly/open-geo-data/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.parquet
+  url: https://github.com/opendataphilly/odp-data-storage/blob/master/philadelphia-neighborhoods/philadelphia-neighborhoods.parquet
 schema: philadelphia
 source: 'Robert Cheetham'
 tags: 


### PR DESCRIPTION
I had changed the repository name a few weeks ago to make it more generic. While these resources would have redirected, I thought it would be better to have the current location. Updated metadata and data modified dates along the way.