### PR TITLE
Update CODEOWNERS to include additional owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners
-* @lydiascarf @BryanQuigley
+* @lydiascarf @BryanQuigley @rcheetham @themightychris
 /_datasets/ @rcheetham @Kistine
-/_organizations/city-of-philadelphia.md @lydiascarf @BryanQuigley @jrmidkiff
+/_organizations/city-of-philadelphia.md @lydiascarf @BryanQuigley


### PR DESCRIPTION
Adding Chris Alfano and myself to default list. Removed James Midkiff as it's not clear that he's made any contributions